### PR TITLE
handle errors when missing required fields in iso8601 job

### DIFF
--- a/src/main/scala/org/apache/mesos/chronos/scheduler/api/ChronosRestModule.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/api/ChronosRestModule.scala
@@ -44,13 +44,16 @@ class ChronosRestModule extends ServletModule {
   }
 
   protected override def configureServlets() {
+
     bind(classOf[ObjectMapper])
       .annotatedWith(Names.named("restMapper"))
       .toInstance(new ObjectMapper())
 
+
     bind(classOf[PingServlet]).in(Scopes.SINGLETON)
     bind(classOf[MetricsServlet]).in(Scopes.SINGLETON)
     bind(classOf[LogConfigServlet]).in(Scopes.SINGLETON)
+    bind(classOf[RequiredFieldMissingExceptionMapper]).in(Scopes.SINGLETON)
     bind(classOf[ConstraintViolationExceptionMapper]).in(Scopes.SINGLETON)
 
     serve(pingUrl).`with`(classOf[PingServlet])
@@ -59,6 +62,7 @@ class ChronosRestModule extends ServletModule {
     serve(guiceContainerUrl).`with`(classOf[GuiceContainer])
 
     bind(classOf[Iso8601JobResource]).in(Scopes.SINGLETON)
+    bind(classOf[CronJobResource]).in(Scopes.SINGLETON)
     bind(classOf[DependentJobResource]).in(Scopes.SINGLETON)
     bind(classOf[JobManagementResource]).in(Scopes.SINGLETON)
     bind(classOf[TaskManagementResource]).in(Scopes.SINGLETON)

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/api/ExceptionMapper.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/api/ExceptionMapper.scala
@@ -1,0 +1,20 @@
+package org.apache.mesos.chronos.scheduler.api
+
+import java.util.logging.{Level, Logger}
+import org.apache.mesos.chronos.utils.RequiredFieldMissingException
+
+import javax.ws.rs.ext.ExceptionMapper;
+import com.fasterxml.jackson.databind.JsonMappingException
+import javax.ws.rs.core.{MediaType, Response}
+import javax.ws.rs.ext.Provider
+
+
+@Provider
+class RequiredFieldMissingExceptionMapper extends ExceptionMapper[RequiredFieldMissingException] {
+  private val log = Logger.getLogger(getClass.getName)
+
+  def toResponse(exception: RequiredFieldMissingException): Response = {
+      log.info(exception.getMessage)
+      return Response.status(422).entity(Map("errors" -> List(s"${exception.getMessage}"))).build
+  }
+}

--- a/src/main/scala/org/apache/mesos/chronos/utils/JobDeserializer.scala
+++ b/src/main/scala/org/apache/mesos/chronos/utils/JobDeserializer.scala
@@ -35,7 +35,7 @@ class JobDeserializer extends JsonDeserializer[BaseJob] {
     val name = fieldFromNode("name")
     val command = fieldFromNode("command")
 
-    val requiredFields = List("name", "comamand").zip(List(name, command))
+    val requiredFields = List("name", "command").zip(List(name, command))
     val missingFields = requiredFields.filter(_._2 == None)
 
     val missingFieldNames = missingFields.map(_._1).mkString(",")


### PR DESCRIPTION
rather than throwing a 500 when the required field is missing from
the json body, inform the client of what's missing.

Before:

```

robj@robj-yelp-mb:~/workspace/chronos master % curl -X POST -H "Content-Type: application/json" -d '{"foo": "bar"}' localhost:8081/scheduler/iso8601
<html>
<head>
<meta http-equiv="Content-Type" content="text/html;charset=ISO-8859-1"/>
<title>Error 500 Server Error</title>
</head>
<body>
<h2>HTTP ERROR: 500</h2>
<p>Problem accessing /scheduler/iso8601. Reason:
<pre>    Server Error</pre></p>
<hr /><i><small>Powered by Jetty://</small></i>




















</body>
</html>
```

After:

```
robj@robj-yelp-mb:~/workspace/chronos sane-errors-when-missing-fields % curl -X POST -H "Content-Type: application/json" -d '{"foo": "bar"}' localhost:8081/scheduler/iso8601
{"errors":["Missing required fields: name,command"]}% 
```
