### PR TITLE
PAASTA-4133 - moving bin script to location in official packages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -528,7 +528,7 @@
                           </data>
                           <data>
                               <src>${basedir}/src/deb/chronos.bash</src>
-                              <dst>/opt/chronos/bin/chronos</dst>
+                              <dst>/usr/bin/chronos</dst>
                               <type>file</type>
                               <mapper>
                                   <type>perm</type>

--- a/src/deb/chronos.init
+++ b/src/deb/chronos.init
@@ -35,7 +35,7 @@ MESOS_HOME=/opt/mesos
 
 . /etc/default/chronos
 
-DAEMON="${CHRONOS_HOME}/bin/chronos"
+DAEMON="chronos"
 if [ "$(id -u)" -ne "0" ]; then
   echo "you must be root to start ${DESC}"
   exit 1


### PR DESCRIPTION
Moves `chronos` bash script to /usr/bin, which is where the officially packaged executable is in installed.
