### PR TITLE
Fixing package versions by replacing the right variable

### DIFF
--- a/deb-build.sh
+++ b/deb-build.sh
@@ -18,12 +18,14 @@ cd chronos
 PROJECT_VER=`mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version\
     |grep '^[0-9].*' | tail -n 1|xargs echo -n`
 PKG_REL="0.1.`date -u +'%Y%m%d%H%M%S'`"
+GIT_VER=`git describe`
 cd ..
 make PKG_VER="$PROJECT_VER" PKG_REL="$PKG_REL" $TARGETS
 cp *.deb chronos/dist
 
 # Create bintray config for travis
 # replaces placeholders with our vars
-sed -e "s/\${project_version}/$MVN_VER/"\
+sed -e "s/\${project_version}/$PROJECT_VER/"\
     -e "s/\${build_timestamp}/`date -u +'%Y-%m-%d'`/"\
+    -e "s/\${git_version}/$GIT_VER/"/
     chronos/src/deb/bintray.json > chronos/dist/bintray.json

--- a/src/deb/bintray.json
+++ b/src/deb/bintray.json
@@ -20,7 +20,7 @@
         "name": "${project_version}",
         "desc": "Version ${project_version}",
         "released": "${build_timestamp}",
-        "vcs_tag": "${project_version}",
+        "vcs_tag": "${git_version}",
         "attributes": [],
         "gpgSign": false
     },


### PR DESCRIPTION
The build currently fails as the bintray.json has an empty version number. This change uses the correct variable substitution to get the version into the json.

It also more accurately gets the git tag into the vcs_tag field in the json.
