### PR TITLE
Avoid apache repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,11 @@
 
   <repositories>
     <repository>
+        <id>central</id>
+        <name>Maven Centra</name>
+        <url>http://repo.maven.apache.org/maven2/</url>
+    </repository>
+    <repository>
       <id>mesosphere-public-repo</id>
       <name>Mesosphere Public Snapshot Repo</name>
       <url>http://downloads.mesosphere.com/maven</url>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
   <repositories>
     <repository>
         <id>central</id>
-        <name>Maven Centra</name>
+        <name>Maven Central</name>
         <url>http://repo.maven.apache.org/maven2/</url>
     </repository>
     <repository>


### PR DESCRIPTION
Builds are currently failing due to the apache maven repository responding really slowly.
This change uses the Apache Maven Central repository first, then tries the other repos.

Only merge if travis build succeeds.
