### PR TITLE
move guice container base url to /

### DIFF
--- a/src/main/scala/org/apache/mesos/chronos/scheduler/api/ChronosRestModule.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/api/ChronosRestModule.scala
@@ -23,7 +23,7 @@ import mesosphere.chaos.validation.{ConstraintViolationExceptionMapper, JacksonM
 
 class ChronosRestModule extends ServletModule {
 
-  val guiceContainerUrl = "/scheduler/*"
+  val guiceContainerUrl = "/*"
 
   // Override these in a subclass to mount resources at a different path
   val pingUrl = "/ping"

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/api/PathConstants.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/api/PathConstants.scala
@@ -4,21 +4,29 @@ package org.apache.mesos.chronos.scheduler.api
  * @author Florian Leibert (flo@leibert.de)
  */
 object PathConstants {
-  final val iso8601JobPath = "/iso8601"
-  final val dependentJobPath = "/dependency"
-  final val infoPath = "/info"
 
-  final val jobBasePath = "/"
-  final val jobPatternPath = "job/{jobName}"
-  final val allJobsPath = "jobs"
+  /*
+   *  scheduler api
+   */
+  final val iso8601JobPath = "scheduler/iso8601"
+  final val dependentJobPath = "scheduler/dependency"
+
+
+  final val jobBasePath = "scheduler/"
+  final val allJobsPath = "jobs/"
   final val jobSearchPath = "jobs/search"
-  final val allStatsPath = "stats/{percentile}"
+  final val jobPatternPath = "job/{jobName}"
+
   final val jobStatsPatternPath = "job/stat/{jobName}"
   final val jobTaskProgressPath = "job/{jobName}/task/{taskId}/progress"
   final val jobSuccessPath = "job/success/{jobName}"
-  final val graphBasePath = "/graph"
+
+  final val allStatsPath = "scheduler/stats/{percentile}"
+  final val graphBasePath = "scheduler/graph/"
   final val jobGraphDotPath = "dot"
   final val jobGraphCsvPath = "csv"
+
+  final val taskBasePath = "/scheduler/task/"
   final val killTaskPattern = "kill/{jobName}"
 
   final val isMasterPath = "isMaster"


### PR DESCRIPTION
I want to write api endpoints from `/` rather than `/scheduler`. Move the guice container base url to `/` and change the scheduler url endpoints to be based off `/scheduler`. This _should_ be a noop

@tub ping, review please :)
