### PR TITLE
add an 'info' endpoint to the api akin to marathon's

### DIFF
--- a/src/main/scala/org/apache/mesos/chronos/scheduler/api/ChronosRestModule.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/api/ChronosRestModule.scala
@@ -64,6 +64,7 @@ class ChronosRestModule extends ServletModule {
     bind(classOf[TaskManagementResource]).in(Scopes.SINGLETON)
     bind(classOf[GraphManagementResource]).in(Scopes.SINGLETON)
     bind(classOf[StatsResource]).in(Scopes.SINGLETON)
+    bind(classOf[InfoResource]).in(Scopes.SINGLETON)
     bind(classOf[RedirectFilter]).in(Scopes.SINGLETON)
     bind(classOf[CorsFilter]).in(Scopes.SINGLETON)
     //This filter will redirect to the master if running in HA mode.

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/api/InfoResource.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/api/InfoResource.scala
@@ -59,7 +59,7 @@ class InfoResource @Inject()(
       "mail_server" -> schedulerConfiguration.mailServer.get.getOrElse("None"),
       "mail_user" -> schedulerConfiguration.mailUser.get.getOrElse("None"),
       "mail_from" -> schedulerConfiguration.mailFrom.get.getOrElse("None"),
-      "mail_ssl_on" -> schedulerConfiguration.mailFrom.get.getOrElse("None")
+      "mail_ssl_on" -> schedulerConfiguration.mailSslOn()
     )
     val zookeeperConfig = Map(
       "zk_hosts" -> schedulerConfiguration.zookeeperServersString(),

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/api/InfoResource.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/api/InfoResource.scala
@@ -30,18 +30,32 @@ class InfoResource @Inject()(
     val frameworkId = frameworkIdUtil.fetch
 
     val chronosConfiguration = Map(
-        "master" -> schedulerConfiguration.master(),
         "user" -> schedulerConfiguration.user(),
-        "failoverTimeoutSeconds" -> schedulerConfiguration.failoverTimeoutSeconds(),
-        "schedulerHorizonSeconds" -> schedulerConfiguration.scheduleHorizonSeconds(),
-        "clusterName" -> schedulerConfiguration.clusterName.get.getOrElse("None"),
+        "failover_timeout" -> schedulerConfiguration.failoverTimeoutSeconds(),
+        "scheduler_horizon" -> schedulerConfiguration.scheduleHorizonSeconds(),
+        "cluster_name" -> schedulerConfiguration.clusterName.get.getOrElse("None"),
         "hostname" -> schedulerConfiguration.hostname(),
-        "leaderMaxIdleTime" -> schedulerConfiguration.leaderMaxIdleTimeMs(),
-        "minReviveOffersInterval" -> schedulerConfiguration.minReviveOffersInterval(),
-        "declineOfferDuration" -> schedulerConfiguration.declineOfferDuration.get.getOrElse("None"),
-        "reconciliationInterval" -> schedulerConfiguration.reconciliationInterval(),
-        "defaultTaskEpsilon" -> schedulerConfiguration.taskEpsilon.get.getOrElse("defaultTaskEpsilon")
+        "leader_max_idle_time" -> schedulerConfiguration.leaderMaxIdleTimeMs(),
+        "min_revive_offers_interval" -> schedulerConfiguration.minReviveOffersInterval(),
+        "decline_offer_duration" -> schedulerConfiguration.declineOfferDuration.get.getOrElse("None"),
+        "reconciliation_interval" -> schedulerConfiguration.reconciliationInterval(),
+        "default_task_epsilon" -> schedulerConfiguration.taskEpsilon.get.getOrElse("defaultTaskEpsilon"),
+        "failure_retry_delay" -> schedulerConfiguration.failureRetryDelayMs(),
+        "disable_after_failures" -> schedulerConfiguration.disableAfterFailures(),
+        "task_epsilon" -> schedulerConfiguration.taskEpsilon(),
+        "reconciliation_interval" -> schedulerConfiguration.reconciliationInterval()
     )
+    val mesosConfig = Map(
+        "master" -> schedulerConfiguration.master(),
+        "mesos_task_mem" -> schedulerConfiguration.mesosTaskMem(),
+        "mesos_task_cpu" -> schedulerConfiguration.mesosTaskCpu(),
+        "mesos_task_disk" -> schedulerConfiguration.mesosTaskDisk(),
+        "mesos_checkpoint" -> schedulerConfiguration.mesosCheckpoint(),
+        "mesos_role" -> schedulerConfiguration.mesosRole(),
+        "mesos_framework_name" -> schedulerConfiguration.mesosFrameworkName(),
+        "mesos_authentication_principal" -> schedulerConfiguration.mesosAuthenticationPrincipal.get.getOrElse("None")
+    )
+
     val mailConfig = Map(
       "mail_server" -> schedulerConfiguration.mailServer.get.getOrElse("None"),
       "mail_user" -> schedulerConfiguration.mailUser.get.getOrElse("None"),
@@ -49,8 +63,9 @@ class InfoResource @Inject()(
       "mail_ssl_on" -> schedulerConfiguration.mailFrom.get.getOrElse("None")
     )
     val zookeeperConfig = Map(
-      "zookeeperTimeout" -> schedulerConfiguration.zooKeeperTimeout(),
-      "zookeeperPath" -> schedulerConfiguration.zooKeeperPath()
+      "zk_hosts" -> schedulerConfiguration.zookeeperServersString(),
+      "zookeeper_timeout" -> schedulerConfiguration.zooKeeperTimeout(),
+      "zookeeper_path" -> schedulerConfiguration.zooKeeperPath()
     )
     Response.ok(
        Map(
@@ -59,7 +74,8 @@ class InfoResource @Inject()(
          "frameworkId" -> frameworkId.get.getValue,
          "mail_config" -> mailConfig,
          "zookeeper_config" -> zookeeperConfig,
-         "schedulerConfiguration" -> chronosConfiguration
+         "mesos_config" -> mesosConfig,
+         "chronos_configuration" -> chronosConfiguration
        )
     ).build
   }

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/api/InfoResource.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/api/InfoResource.scala
@@ -1,17 +1,16 @@
 package org.apache.mesos.chronos.scheduler.api
 
-import org.apache.mesos.chronos.scheduler.config.SchedulerConfiguration
-import org.apache.curator.framework.recipes.leader.{LeaderLatch, Participant}
-import mesosphere.chaos.http.HttpConf
-import mesosphere.mesos.util.FrameworkIdUtil
-import org.apache.mesos.Protos.FrameworkID
+import java.util.logging.Logger
 
-import java.util.logging.{Level, Logger}
-import javax.ws.rs._
-import javax.ws.rs.core.Response.Status
-import javax.ws.rs.core.{MediaType, Response}
 import scala.util.Try
+
 import com.google.inject.Inject
+import javax.ws.rs._
+import javax.ws.rs.core.{Response, MediaType}
+import mesosphere.mesos.util.FrameworkIdUtil
+import org.apache.curator.framework.recipes.leader.LeaderLatch
+import org.apache.mesos.Protos.FrameworkID
+import org.apache.mesos.chronos.scheduler.config.SchedulerConfiguration
 
 @Path(PathConstants.infoPath)
 class InfoResource @Inject()(
@@ -25,8 +24,8 @@ class InfoResource @Inject()(
   @Produces(Array(MediaType.APPLICATION_JSON))
   def info(): Response = {
 
-    import scala.concurrent.ExecutionContext.Implicits.global
     import mesosphere.util.BackToTheFuture.Implicits.defaultTimeout
+    import scala.concurrent.ExecutionContext.Implicits.global
     val frameworkId = frameworkIdUtil.fetch
 
     val chronosConfiguration = Map(

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/api/InfoResource.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/api/InfoResource.scala
@@ -1,0 +1,64 @@
+package org.apache.mesos.chronos.scheduler.api
+
+import org.apache.mesos.chronos.scheduler.config.SchedulerConfiguration
+import org.apache.mesos.chronos.scheduler.config.SchedulerConfiguration
+import mesosphere.chaos.http.HttpConf
+import mesosphere.mesos.util.FrameworkIdUtil
+import org.apache.mesos.Protos.FrameworkID
+
+import java.util.logging.{Level, Logger}
+import javax.ws.rs._
+import javax.ws.rs.core.Response.Status
+import javax.ws.rs.core.{MediaType, Response}
+import com.google.inject.Inject
+
+@Path(PathConstants.infoPath)
+class InfoResource @Inject()(
+  val schedulerConfiguration: SchedulerConfiguration,
+  val frameworkIdUtil: FrameworkIdUtil
+) {
+  private val log = Logger.getLogger(getClass.getName)
+
+  @GET
+  @Produces(Array(MediaType.APPLICATION_JSON))
+  def info(): Response = {
+
+    import scala.concurrent.ExecutionContext.Implicits.global
+    import mesosphere.util.BackToTheFuture.Implicits.defaultTimeout
+    val frameworkId = frameworkIdUtil.fetch
+
+    val chronosConfiguration = Map(
+        "master" -> schedulerConfiguration.master(),
+        "user" -> schedulerConfiguration.user(),
+        "failoverTimeoutSeconds" -> schedulerConfiguration.failoverTimeoutSeconds(),
+        "schedulerHorizonSeconds" -> schedulerConfiguration.scheduleHorizonSeconds(),
+        "clusterName" -> schedulerConfiguration.clusterName.get.getOrElse("None"),
+        "hostname" -> schedulerConfiguration.hostname(),
+        "leaderMaxIdleTime" -> schedulerConfiguration.leaderMaxIdleTimeMs(),
+        "minReviveOffersInterval" -> schedulerConfiguration.minReviveOffersInterval(),
+        "declineOfferDuration" -> schedulerConfiguration.declineOfferDuration.get.getOrElse("None"),
+        "reconciliationInterval" -> schedulerConfiguration.reconciliationInterval(),
+        "defaultTaskEpsilon" -> schedulerConfiguration.taskEpsilon.get.getOrElse("defaultTaskEpsilon")
+    )
+    val mailConfig = Map(
+      "mail_server" -> schedulerConfiguration.mailServer.get.getOrElse("None"),
+      "mail_user" -> schedulerConfiguration.mailUser.get.getOrElse("None"),
+      "mail_password" -> schedulerConfiguration.mailUser.get.getOrElse("None"),
+      "mail_from" -> schedulerConfiguration.mailFrom.get.getOrElse("None"),
+      "mail_ssl_on" -> schedulerConfiguration.mailFrom.get.getOrElse("None")
+    )
+    val zookeeperConfig = Map(
+      "zookeeperTimeout" -> schedulerConfiguration.zooKeeperTimeout(),
+      "zookeeperPath" -> schedulerConfiguration.zooKeeperPath()
+    )
+    Response.ok(
+       Map(
+         "version" -> schedulerConfiguration.version,
+         "frameworkId" -> frameworkId.get.getValue,
+         "mail_config" -> mailConfig,
+         "zookeeper_config" -> zookeeperConfig,
+         "schedulerConfiguration" -> chronosConfiguration
+       )
+    ).build
+  }
+}

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/api/InfoResource.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/api/InfoResource.scala
@@ -43,7 +43,6 @@ class InfoResource @Inject()(
     val mailConfig = Map(
       "mail_server" -> schedulerConfiguration.mailServer.get.getOrElse("None"),
       "mail_user" -> schedulerConfiguration.mailUser.get.getOrElse("None"),
-      "mail_password" -> schedulerConfiguration.mailUser.get.getOrElse("None"),
       "mail_from" -> schedulerConfiguration.mailFrom.get.getOrElse("None"),
       "mail_ssl_on" -> schedulerConfiguration.mailFrom.get.getOrElse("None")
     )

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/api/PathConstants.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/api/PathConstants.scala
@@ -29,6 +29,7 @@ object PathConstants {
   final val taskBasePath = "/scheduler/task/"
   final val killTaskPattern = "kill/{jobName}"
 
+  final val isMasterPath = "isMaster"
   final val infoPath = "info"
   final val uriTemplate = "http://%s%s"
 }

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/api/PathConstants.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/api/PathConstants.scala
@@ -29,7 +29,6 @@ object PathConstants {
   final val taskBasePath = "/scheduler/task/"
   final val killTaskPattern = "kill/{jobName}"
 
-  final val isMasterPath = "isMaster"
-  final val taskBasePath = "/task"
+  final val infoPath = "info"
   final val uriTemplate = "http://%s%s"
 }

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/api/InfoResourceTest.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/api/InfoResourceTest.scala
@@ -1,0 +1,36 @@
+package org.apache.mesos.chronos.scheduler.api
+
+import mesosphere.mesos.util.FrameworkIdUtil
+import org.apache.curator.framework.recipes.leader.LeaderLatch
+import org.apache.mesos.Protos.FrameworkID
+import org.apache.mesos.chronos.ChronosTestHelper
+import org.apache.mesos.chronos.scheduler.config.SchedulerConfiguration
+import org.mockito.Mockito.when
+import org.specs2.mock._
+import org.specs2.mutable.SpecificationWithJUnit
+import org.specs2.specification.Scope
+
+class InfoResourceSpec extends SpecificationWithJUnit with Mockito {
+  "InfoResource" should {
+    "Return the expected keys in the JSON" in {
+        val fixture = new Fixture
+        val resource = fixture.infoResource()
+        val response = resource.info()
+        val content = response.getEntity()
+        response.getStatus should be equalTo(200)
+     }
+   }
+
+   class Fixture {
+        val frameworkId = FrameworkID.newBuilder
+            .setValue("some_id")
+            .build()
+        val schedulerConfiguration = ChronosTestHelper.makeConfig()
+        val frameworkIdUtil = mock[FrameworkIdUtil]
+        implicit val timeout =  mesosphere.util.BackToTheFuture.Implicits.defaultTimeout
+        implicit val context = scala.concurrent.ExecutionContext.Implicits.global
+        when(frameworkIdUtil.fetch(context, timeout)).thenReturn(Some(frameworkId))
+        val leaderLatch = mock[LeaderLatch]
+        def infoResource() = new InfoResource(schedulerConfiguration, frameworkIdUtil, leaderLatch)
+    }
+}


### PR DESCRIPTION
up for early review and suggestions on what other info we might want here.

@tub @solarkennedy thoughts?

```
robj@robj-yelp-mb:~/workspace/chronos info-api % curl http://0.0.0.0:8081/info | jq .
{
  "schedulerConfiguration": {
    "defaultTaskEpsilon": 60,
    "hostname": "b905ec02e1ac",
    "schedulerHorizonSeconds": 60,
    "master": "zk://zookeeper:2181/mesos-testcluster",
    "failoverTimeoutSeconds": 604800,
    "declineOfferDuration": "None",
    "minReviveOffersInterval": 5000,
    "reconciliationInterval": 600,
    "leaderMaxIdleTime": 5000,
    "clusterName": "None",
    "user": "root"
  },
  "mail_config": {
    "mail_user": "None",
    "mail_from": "None",
    "mail_ssl_on": "None",
    "mail_server": "None",
    "mail_password": "None"
  },
  "frameworkId": "058f572c-9040-46f6-a86a-f8b37acabdeb-0000",
  "version": "2.5.0-yelp14-SNAPSHOT",
  "zookeeper_config": {
    "zookeeperTimeout": 10000,
    "zookeeperPath": "/chronos"
  }
}
```
