### PR TITLE
add a /leader endpoint to the api

### DIFF
--- a/src/main/scala/org/apache/mesos/chronos/scheduler/api/ChronosRestModule.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/api/ChronosRestModule.scala
@@ -65,6 +65,7 @@ class ChronosRestModule extends ServletModule {
     bind(classOf[GraphManagementResource]).in(Scopes.SINGLETON)
     bind(classOf[StatsResource]).in(Scopes.SINGLETON)
     bind(classOf[InfoResource]).in(Scopes.SINGLETON)
+    bind(classOf[LeaderResource]).in(Scopes.SINGLETON)
     bind(classOf[RedirectFilter]).in(Scopes.SINGLETON)
     bind(classOf[CorsFilter]).in(Scopes.SINGLETON)
     //This filter will redirect to the master if running in HA mode.

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/api/LeaderResource.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/api/LeaderResource.scala
@@ -1,0 +1,20 @@
+package org.apache.mesos.chronos.scheduler.api
+
+import com.google.inject.Inject
+import javax.ws.rs.{GET, Path, Produces}
+import javax.ws.rs.core.Response
+import org.apache.mesos.chronos.scheduler.jobs.JobScheduler
+
+
+@Path(PathConstants.leaderPath)
+class LeaderResource @Inject()(
+  val jobScheduler: JobScheduler
+) {
+
+  @GET
+  @Produces(Array(MediaType.APPLICATION_JSON))
+  def getLeader(): Response = {
+    Response.ok(Map("leader" -> jobScheduler.getLeader)).build
+
+  }
+}

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/api/PathConstants.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/api/PathConstants.scala
@@ -31,5 +31,6 @@ object PathConstants {
 
   final val isMasterPath = "isMaster"
   final val infoPath = "info"
+  final val leaderPath = "leader"
   final val uriTemplate = "http://%s%s"
 }

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/api/LeaderResourceTest.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/api/LeaderResourceTest.scala
@@ -1,0 +1,24 @@
+package org.apache.mesos.chronos.scheduler.api
+
+import org.apache.mesos.chronos.scheduler.jobs.JobScheduler
+import org.mockito.Mockito.when
+import org.specs2.mock._
+import org.specs2.mutable.SpecificationWithJUnit
+import org.specs2.specification.Scope
+
+class LeaderResourceSpec extends SpecificationWithJUnit with Mockito {
+  "LeaderResource" should {
+    "Return a 200" in {
+        val fixture = new Fixture
+        val resource = fixture.leaderResource()
+        val response = resource.getLeader()
+        response.getStatus should be equalTo(200)
+     }
+   }
+
+   class Fixture {
+        val mockScheduler = mock[JobScheduler]
+        when(mockScheduler.getLeader).thenReturn("hostname")
+        def leaderResource() = new LeaderResource(mockScheduler)
+    }
+}


### PR DESCRIPTION
replaces #1
