### PR TITLE
Track completed edges

### DIFF
--- a/src/main/scala/org/apache/mesos/chronos/scheduler/api/JobManagementResource.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/api/JobManagementResource.scala
@@ -151,7 +151,8 @@ class JobManagementResource @Inject()(val jobScheduler: JobScheduler,
       require(jobGraph.lookupVertex(jobName).isDefined, "Job '%s' not found".format(jobName))
       val job = jobGraph.getJobForName(jobName).get
       log.info("Manually triggering job:" + jobName)
-      jobScheduler.taskManager.enqueue(TaskUtils.getTaskId(job, DateTime.now(DateTimeZone.UTC), 0), job.highPriority)
+      jobScheduler.taskManager.enqueue(TaskUtils.getTaskId(job, DateTime.now(DateTimeZone.UTC), 0, Option(arguments).filter(_.trim.nonEmpty))
+        , job.highPriority)
       Response.noContent().build
     } catch {
       case ex: IllegalArgumentException =>

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/TaskUtils.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/TaskUtils.scala
@@ -2,8 +2,8 @@ package org.apache.mesos.chronos.scheduler.jobs
 
 import java.util.logging.Logger
 
-import org.apache.mesos.chronos.scheduler.state.PersistenceStore
 import org.apache.mesos.Protos.{TaskID, TaskState, TaskStatus}
+import org.apache.mesos.chronos.scheduler.state.PersistenceStore
 import org.joda.time.{DateTime, DateTimeZone}
 
 import scala.collection.mutable
@@ -22,6 +22,8 @@ object TaskUtils {
   val taskIdTemplate = "ct:%d:%d:%s:%s"
   val argumentsPattern = """(.*)?""".r
   val taskIdPattern = """ct:(\d+):(\d+):%s:?%s""".format(JobUtils.jobNamePattern, argumentsPattern).r
+  val commandInjectionFilter = ";".toSet
+
   private[this] val log = Logger.getLogger(getClass.getName)
 
   def getTaskStatus(job: BaseJob, due: DateTime, attempt: Int = 0): TaskStatus = {
@@ -99,8 +101,9 @@ object TaskUtils {
     })
   }
 
-  def getTaskId(job: BaseJob, due: DateTime, attempt: Int = 0): String = {
-    taskIdTemplate.format(due.getMillis, attempt, job.name, job.arguments.mkString(" "))
+  def getTaskId(job: BaseJob, due: DateTime, attempt: Int = 0, arguments: Option[String] = None): String = {
+    val args: String = arguments.getOrElse(job.arguments.mkString(" ")).filterNot(commandInjectionFilter)
+    taskIdTemplate.format(due.getMillis, attempt, job.name, args)
   }
 
   def getDueTimes(tasks: Map[String, Array[Byte]]): Map[String, (BaseJob, Long, Int)] = {

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/JobSchedulerIntegrationTest.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/JobSchedulerIntegrationTest.scala
@@ -114,7 +114,7 @@ class JobSchedulerIntegrationTest extends SpecificationWithJUnit with Mockito {
       jobMarkedSuccess.successCount must_== 1
       jobMarkedSuccess.errorsSinceLastSuccess must_== 0
       val lastSuccess = DateTime.parse(jobMarkedSuccess.lastSuccess)
-      there was one(mockTaskManager).enqueue(TaskUtils.getTaskId(dependentJob, lastSuccess, 0),
+      there was one(mockTaskManager).enqueue(TaskUtils.getTaskId(dependentJob, lastSuccess, 0, None),
         highPriority = false)
       scheduler.handleStartedTask(TaskUtils.getTaskStatus(dependentJob, lastSuccess, 0))
       scheduler.handleFinishedTask(TaskUtils.getTaskStatus(dependentJob, lastSuccess, 0))


### PR DESCRIPTION
hey @huadongliu

a bunch of these changes come from upstream, so ignore the changes to JobManagementResource.scala and TaskUtils.

As we spoke about, I'm super early into this, and haven't even figured out if this is a viable solution. We need to find all the places where `edgeInvocationCount`  is currently modified and make sure we do the same thing (though, obviously, fixing it where we think we should). All I've got right now is doing the right thing when a given parent job finishes - next thing will be clearing it when it failed and figuring out how we put this in ZK so that it's persisted between failovers.

I'm running zookeeper, mesos-master and mesos-slave locally - clone the mesos repo and run 
`$ /usr/local/sbin/mesos-master --registry=in_memory --ip=127.0.0.1 --zk=zk://0.0.0.0:32768/mesos-testcluster`
`$ sudo /usr/local/sbin/mesos-slave --master=127.0.0.1:5050 --master=zk://0.0.0.0:32768/mesos-testcluster`

of course you'll have to adjust the zk location for your setup.

I run chronos with the following arguments

`
--zk_hosts 0.0.0.0:32768 --zk_path /chronos --http_port 8081 --master zk://0.0.0.0:32768/mesos-testcluster
`

Push any progress to this branch - don't worry about making it tidy or anything for now, and we cleanup later.
