### PR TITLE
Fixes #30 by failing fast in deb-build.sh

### DIFF
--- a/deb-build.sh
+++ b/deb-build.sh
@@ -3,6 +3,9 @@
 # This script is designed to be run within the
 # Dockerfile.deb-build docker image
 
+# Fail quickly if any command exits uncleanly
+set -e
+
 # build targets are passed in as first parameter
 # values for this can be found in github mesosphere/chronos-pkg/Makefile
 TARGETS=$1


### PR DESCRIPTION
Makes deb-build.sh exit if any commands exit uncleanly by setting -e

This should prevent issues like #28 not being noticed because of the build exiting with the wrong return code.
