### PR TITLE
Build chronos for xenial and remove lucid

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,13 @@ branches:
   only:
     - master
     - /^v[0-9.]+/
+env:
+  - MAKE_TARGET=itest_trusty
+  - MAKE_TARGET=itest_xenial
 sudo: required
 services:
   - docker
-script: make itest_trusty
+script: if [[ -n "$MAKE_TARGET" ]]; then make "$MAKE_TARGET"; fi
 cache:
   directories:
     - $HOME/.m2/repository

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,7 @@
 
 itest_trusty: docker-run-ubuntu-trusty
 
-# Yes, we just run the same package as trusty, it's just some java ;)
-itest_lucid: docker-run-ubuntu-trusty
+itest_xenial: docker-run-ubuntu-xenial
 
 release: docker-build
 	# create correctly versioned poms, tag and push. Don't bother running tests as travis/jenkins will run them

--- a/deb-build.sh
+++ b/deb-build.sh
@@ -31,4 +31,5 @@ cp *.deb chronos/dist
 sed -e "s/\${project_version}/$PROJECT_VER/"\
     -e "s/\${build_timestamp}/`date -u +'%Y-%m-%d'`/"\
     -e "s/\${git_version}/$PROJECT_VER/"\
+    -e "s/\${project_distribution}/${TARGETS#ubuntu-}/"\
     chronos/src/deb/bintray.json > chronos/dist/bintray.json

--- a/src/deb/bintray.json
+++ b/src/deb/bintray.json
@@ -27,7 +27,7 @@
 
     "files":
         [
-        {"includePattern": "dist/(.*.deb)", "uploadPattern": "$1", "matrixParams": { "deb_distribution": "lucid,trusty", "deb_component": "main", "deb_architecture": "amd64"} }
+        {"includePattern": "dist/(.*.deb)", "uploadPattern": "$1", "matrixParams": { "deb_distribution": "${project_distribution}", "deb_component": "main", "deb_architecture": "amd64"} }
         ],
     "publish": true
 }


### PR DESCRIPTION
Ubuntu Xenial is the latest LTS release. Lucid is EOL. Let's start building chronos for Xenial and drop Lucid.

To make this work, I've done some slight refactoring to the travis build process to support calling multiple Makefile targets and setting the correct `deb_distribution` on bintray.
