### PR TITLE
ignore unparseable status updates for MESOS-4084

### DIFF
--- a/src/main/scala/org/apache/mesos/chronos/scheduler/mesos/MesosJobFramework.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/mesos/MesosJobFramework.scala
@@ -201,12 +201,12 @@ class MesosJobFramework @Inject()(
 
   @Override
   def statusUpdate(schedulerDriver: SchedulerDriver, taskStatus: TaskStatus) {
-    if(TaskUtils.isValidVersion(taskStatus.getTaskId.getValue)) {
-      val taskId = taskStatus.getTaskId.getValue
-      val state = taskStatus.getState
+    val taskId = taskStatus.getTaskId.getValue
+    val state = taskStatus.getState
+    if(TaskUtils.isValidVersion(taskId)) {
       taskManager.taskCache.put(taskId, state)
-      val (jobName, _, _, _) = TaskUtils.parseTaskId(taskStatus.getTaskId.getValue)
-      taskStatus.getState match {
+      val (jobName, _, _, _) = TaskUtils.parseTaskId(taskId)
+      state match {
         case TaskState.TASK_RUNNING =>
           scheduler.handleStartedTask(taskStatus)
           updateRunningTask(jobName, taskStatus)
@@ -218,29 +218,29 @@ class MesosJobFramework @Inject()(
       }
 
       //TOOD(FL): Add statistics for jobs
-      taskStatus.getState match {
+      state match {
         case TaskState.TASK_FINISHED =>
-          log.info("Task with id '%s' FINISHED".format(taskStatus.getTaskId.getValue))
+          log.info("Task with id '%s' FINISHED".format(taskId))
           //This is a workaround to support async jobs without having to keep yet more state.
-          if (scheduler.isTaskAsync(taskStatus.getTaskId.getValue)) {
-            log.info("Asynchronous task: '%s', not updating job-graph.".format(taskStatus.getTaskId.getValue))
+          if (scheduler.isTaskAsync(taskId)) {
+            log.info("Asynchronous task: '%s', not updating job-graph.".format(taskId))
           } else {
             scheduler.handleFinishedTask(taskStatus)
           }
         case TaskState.TASK_FAILED =>
-          log.info("Task with id '%s' FAILED".format(taskStatus.getTaskId.getValue))
+          log.info("Task with id '%s' FAILED".format(taskId))
           scheduler.handleFailedTask(taskStatus)
         case TaskState.TASK_LOST =>
-          log.info("Task with id '%s' LOST".format(taskStatus.getTaskId.getValue))
+          log.info("Task with id '%s' LOST".format(taskId))
           scheduler.handleFailedTask(taskStatus)
         case TaskState.TASK_RUNNING =>
-          log.info("Task with id '%s' RUNNING. Removing persistence task.".format(taskStatus.getTaskId.getValue))
+          log.info("Task with id '%s' RUNNING. Removing persistence task.".format(taskId))
           taskManager.removeTask(taskStatus.getTaskId.getValue)
         case TaskState.TASK_KILLED =>
-          log.info("Task with id '%s' KILLED.".format(taskStatus.getTaskId.getValue))
+          log.info("Task with id '%s' KILLED.".format(taskId))
           scheduler.handleKilledTask(taskStatus)
         case _ =>
-          log.warning("Unknown TaskState:" + taskStatus.getState + " for task: " + taskStatus.getTaskId.getValue)
+          log.warning("Unknown TaskState:" + state + " for task: " + taskId)
       }
       // Perform a reconciliation, if needed.
       reconcile(schedulerDriver)


### PR DESCRIPTION
closes #35.

This is the 'quick' fix - I'd much rather fix the actual problem of parsing a task ID throwing an exception rather than returning an `Option`, but that'll take a lot longer (because all the call sites will have to add logic to handle failures) and we need a quick fix.

Rather than trying (and failing terribly) to parse the task ID for another framework's task when we get a status update, ignore it.

Here is the test failing before this:

```
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running org.apache.mesos.chronos.scheduler.mesos.MesosJobFrameworkSpec
Oct 06, 2016 11:28:56 AM org.apache.mesos.chronos.scheduler.mesos.MesosJobFramework reregistered
WARNING: Reregistered
Tests run: 6, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 2.284 sec <<< FAILURE!
Ignore invalid status updates(org.apache.mesos.chronos.scheduler.mesos.MesosJobFrameworkSpec)  Time elapsed: 0.021 sec  <<< FAILURE!
org.specs2.reporter.SpecFailureAssertionFailedError: Got the exception scala.MatchError: BLAHBLAHBLAH (of class java.lang.String)
        at org.apache.mesos.chronos.scheduler.mesos.MesosJobFrameworkSpec$$anonfun$3.apply(MesosJobFrameworkSpec.scala:181)
        at org.apache.mesos.chronos.scheduler.mesos.MesosJobFrameworkSpec$$anonfun$3.apply(MesosJobFrameworkSpec.scala:156)


Results :

Failed tests:
   Got the exception scala.MatchError: BLAHBLAHBLAH (of class java.lang.String)

Tests run: 6, Failures: 1, Errors: 0, Skipped: 0
```

Internally, I'd like to replace our splunk alert with one that looks for the log line I added - we can't make guarantees that every `MatchError` we see is this situation.

`Received StatusUpdate for task with id %s. Likely https://issues.apache.org/jira/browse/MESOS-4084`
