### PR TITLE
Run mvn release outside of docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,15 @@
 # This makefile is only used to build chronos within Yelp's jenkins infrastructure.
 #
 # Maven is still the recommended route for building chronos.
+mvn_var=$(shell which mvn3 || which mvn)
 
 itest_trusty: docker-run-ubuntu-trusty
 
 itest_xenial: docker-run-ubuntu-xenial
 
-release: docker-build
+release:
 	# create correctly versioned poms, tag and push. Don't bother running tests as travis/jenkins will run them
-	docker run -v $(CURDIR):/work:rw chronos_maven_builder bash -c "cd /work && mvn -B release:prepare release:clean"
+	$(mvn_var) -B -DskipTests release:prepare release:clean
 
 docker-run-%: docker-build dist
 	docker run -v $(CURDIR):/work:rw chronos_maven_builder bash -c "/work/deb-build.sh $*"

--- a/README.yelp-release.md
+++ b/README.yelp-release.md
@@ -1,7 +1,7 @@
 # Releasing Chronos at Yelp
 
 ## tl;dr
-* run `make release`, which in turn runs `mvn release:prepare release:perform` in a docker container
+* run `make release`, which in turn runs `mvn release:prepare release:perform`
 * Versions in pom.xml get updated, commited and new tag is pushed to github
 * Travis runs maven on tag, pushes deb to bintray
 * Also mirrored internally for jenkins build


### PR DESCRIPTION
In order to avoid having to set up git and related keys within docker, let's just run the mvn release:prepare step outside of docker. All it does is update the pom files and push a new git tag.
