### PR TITLE
test for the string "null" when parsing stz too

### DIFF
--- a/src/main/scala/org/apache/mesos/chronos/utils/JobDeserializer.scala
+++ b/src/main/scala/org/apache/mesos/chronos/utils/JobDeserializer.scala
@@ -231,7 +231,7 @@ class JobDeserializer extends JsonDeserializer[BaseJob] {
         constraints = constraints)
     } else if (node.has("schedule")) {
       val schedule = node.get("schedule").asText
-      val scheduleTimeZone = if (node.has("scheduleTimeZone") && !node.get("scheduleTimeZone").isNull) {
+      val scheduleTimeZone = if (node.has("scheduleTimeZone") && !node.get("scheduleTimeZone").isNull && node.get("scheduleTimeZone").asText != "null") {
         node.get("scheduleTimeZone").asText
       } else "UTC"
       val parsedSchedule = ParserForSchedule(schedule).flatMap(parser => parser(schedule, scheduleTimeZone))

--- a/src/test/scala/org/apache/mesos/chronos/utils/JobDeserializerSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/utils/JobDeserializerSpec.scala
@@ -29,4 +29,19 @@ class JobDeserializerSpec  extends SpecificationWithJUnit with Mockito {
     val job = deserializer.deserialize(jsonParser, ctxt).asInstanceOf[ScheduleBasedJob]
     job.scheduleTimeZone must_== "UTC"
   }
+  "deals with a null string scheduleTimeZone field" in {
+    val jsonParser = mock[JsonParser]
+    val ctxt = mock[DeserializationContext]
+    val mockCodec = mock[ObjectCodec]
+
+    val mapper = new ObjectMapper
+    val node = mapper.readValue("""{"name": "foo", "command": "bar", "epsilon": "PT20S", "runAsUser": "root", "scheduleTimeZone": "null", "schedule": "R1/2016-10-18T15:39:11.352Z/PT24H"}""", classOf[JsonNode])
+
+    when(mockCodec.readTree(any)).thenReturn(node)
+    when(jsonParser.getCodec).thenReturn(mockCodec)
+
+    val deserializer = new JobDeserializer
+    val job = deserializer.deserialize(jsonParser, ctxt).asInstanceOf[ScheduleBasedJob]
+    job.scheduleTimeZone must_== "UTC"
+  }
 }


### PR DESCRIPTION
when chronos serializes the job to ZK, null gets converted to the
string "null", so a null check is no longer enough - we need to check
for the string "null", too. yeah, ikr.
