### PR TITLE
Exit on loss of ZK connection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <scala.abi>2.11.2</scala.abi>
 
     <!-- runtime deps versions -->
-    <akka.version>2.3.6</akka.version>
+    <akka.version> 2.4.12</akka.version>
     <cassandra-driver-core.version>2.1.0</cassandra-driver-core.version>
     <chaos.version>0.6.3</chaos.version>
     <commons-math3.version>3.2</commons-math3.version>

--- a/src/main/scala/org/apache/mesos/chronos/core/RichRuntime.scala
+++ b/src/main/scala/org/apache/mesos/chronos/core/RichRuntime.scala
@@ -1,0 +1,39 @@
+package org.apache.mesos.chronos.core
+
+import java.util.logging.Logger
+import java.util.{ Timer, TimerTask }
+
+import scala.concurrent.duration._
+import scala.concurrent.{ ExecutionContext, Future, _ }
+
+import akka.Done
+
+class RichRuntime {
+
+  private[this] val logger = Logger.getLogger(getClass.getName)
+
+  def asyncExit(
+    exitCode: Int = RichRuntime.FatalErrorSignal,
+    waitForExit: FiniteDuration = 10.seconds)(implicit ec: ExecutionContext): Future[Done] = {
+    val timer = new Timer()
+    val promise = Promise[Done]()
+    timer.schedule(new TimerTask {
+      override def run(): Unit = {
+        logger.info("Halting JVM")
+        promise.success(Done)
+        Runtime.getRuntime.halt(exitCode)
+      }
+    }, waitForExit.toMillis)
+    Future(sys.exit(exitCode))
+    promise.future
+  }
+}
+
+object RichRuntime {
+  val FatalErrorSignal = 137
+  val DefaultExitDelay = 10.seconds
+
+  def apply(): RichRuntime = {
+    new RichRuntime
+  }
+}

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/JobScheduler.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/JobScheduler.scala
@@ -19,6 +19,7 @@ import org.joda.time.{DateTime, DateTimeZone, Duration, Period}
 
 import scala.annotation.tailrec
 import scala.collection.mutable.ListBuffer
+import scala.concurrent.ExecutionContext
 import org.apache.mesos.chronos.schedule.{CronSchedule, Schedule, ISO8601Schedule}
 
 /**
@@ -610,7 +611,7 @@ class JobScheduler @Inject()(val scheduleHorizon: Period,
 
   //Begin Leader interface, which is required for CandidateImpl.
   def onDefeated() {
-    import scala.concurrent.ExecutionContext.Implicits.global
+    implicit val exitExecutor = ExecutionContext.fromExecutor(Executors.newSingleThreadExecutor)
     log.info("Defeated. Not the current leader. Shutting down.")
     running.set(false)
     val runtime = RichRuntime()

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/mesos/MesosDriverFactory.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/mesos/MesosDriverFactory.scala
@@ -24,6 +24,8 @@ class MesosDriverFactory(
   var mesosDriver: Option[SchedulerDriver] = None
 
   def start(): Unit = {
+    log.info("STARTING MESOS DRIVER")
+    log.info("scheduler IS A %s".format(scheduler.getClass))
     val status = get().start()
     if (status != Status.DRIVER_RUNNING) {
       log.severe(s"MesosSchedulerDriver start resulted in status: $status. Committing suicide!")

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/mesos/MesosJobFramework.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/mesos/MesosJobFramework.scala
@@ -45,6 +45,7 @@ class MesosJobFramework @Inject()(
 
     log.info("Registered with ID: " + frameworkID.getValue)
     log.info("Master info:" + masterInfo.toString)
+    log.info("RUNNING TASKS: %s".format(runningTasks.toString))
     frameworkIdUtil.store(frameworkID)
     mesosOfferReviver.reviveOffers()
   }
@@ -201,6 +202,8 @@ class MesosJobFramework @Inject()(
 
   @Override
   def statusUpdate(schedulerDriver: SchedulerDriver, taskStatus: TaskStatus) {
+    log.info("Got status update: reason: %s state: %s message:".format(taskStatus.getReason, taskStatus.getState, taskStatus.getMessage))
+
     val taskId = taskStatus.getTaskId.getValue
     val state = taskStatus.getState
     if(TaskUtils.isValidVersion(taskId)) {

--- a/src/main/scala/org/apache/mesos/chronos/utils/Lock.scala
+++ b/src/main/scala/org/apache/mesos/chronos/utils/Lock.scala
@@ -1,0 +1,49 @@
+package org.apache.mesos.chronos.utils
+
+import java.util.concurrent.locks.{ ReentrantLock, ReentrantReadWriteLock }
+
+class RichLock(val lock: ReentrantLock) extends AnyVal {
+  def apply[T](f: => T): T = {
+    lock.lock()
+    try {
+      f
+    } finally {
+      lock.unlock()
+    }
+  }
+}
+
+object RichLock {
+  def apply(fair: Boolean = true): RichLock = new RichLock(new ReentrantLock(fair))
+  def apply(lock: ReentrantLock): RichLock = new RichLock(lock)
+}
+
+class Lock[T](private val value: T, fair: Boolean = true) {
+  private val lock = RichLock(fair)
+
+  def apply[R](f: T => R): R = lock {
+    f(value)
+  }
+
+  override def equals(o: Any): Boolean = o match {
+    case r: Lock[T] => lock {
+      r.lock {
+        value.equals(r.value)
+      }
+    }
+    case r: T @unchecked => lock {
+      value.equals(r)
+    }
+    case _ => false
+  }
+
+  override def hashCode(): Int = lock(value.hashCode())
+
+  override def toString: String = lock {
+    value.toString
+  }
+}
+
+object Lock {
+  def apply[T](value: T, fair: Boolean = true): Lock[T] = new Lock(value, fair)
+}

--- a/src/main/scala/org/apache/mesos/chronos/utils/Retry.scala
+++ b/src/main/scala/org/apache/mesos/chronos/utils/Retry.scala
@@ -1,0 +1,100 @@
+package org.apache.mesos.chronos.utils
+
+import akka.actor.Scheduler
+
+import scala.concurrent.duration.{ FiniteDuration, _ }
+import scala.concurrent.{ ExecutionContext, Future, Promise, blocking => blockingCall }
+import scala.util.Random
+import scala.util.control.NonFatal
+import scala.util.Failure
+import scala.util.Success
+
+/**
+  * Functional transforms to retry methods using a form of Exponential Backoff with jitter.
+  *
+  * See also: https://www.awsarchitectureblog.com/2015/03/backoff.html
+  */
+object Retry {
+  val DefaultMaxAttempts = 5
+  val DefaultMinDelay = 10.millis
+  val DefaultMaxDelay = 1.second
+
+  type RetryOnFn = Throwable => Boolean
+  val defaultRetry: RetryOnFn = NonFatal(_)
+
+  private def randomBetween(min: Long, max: Long): Long = {
+    math.abs(Random.nextLong() % (max - min + 1)) + min
+  }
+
+  /**
+    * Retry a non-blocking call
+    * @param maxAttempts The maximum number of attempts before failing
+    * @param minDelay The minimum delay between invocations
+    * @param maxDelay The maximum delay between invocations
+    * @param retryOn A method that returns true for Throwables which should be retried
+    * @param f The method to transform
+    * @param scheduler The akka scheduler to execute on
+    * @param ctx The execution context to run the method on
+    * @tparam T The result type of 'f'
+    * @return The result of 'f', TimeoutException if 'f' failed 'maxAttempts' with retry-able exceptions
+    *         and the last exception that was thrown, or the last exception thrown if 'f' failed with a
+    *         non-retry-able exception.
+    */
+  def apply[T](
+    name: String,
+    maxAttempts: Int = DefaultMaxAttempts,
+    minDelay: Duration = DefaultMinDelay,
+    maxDelay: Duration = DefaultMaxDelay,
+    retryOn: RetryOnFn = defaultRetry)(f: => Future[T])(implicit
+    scheduler: Scheduler,
+    ctx: ExecutionContext): Future[T] = {
+    val promise = Promise[T]()
+
+    def retry(attempt: Int, lastDelay: FiniteDuration): Unit = {
+      f.onComplete {
+        case Success(result) =>
+          promise.success(result)
+        case Failure(e) if retryOn(e) =>
+          if (attempt + 1 < maxAttempts) {
+            val nextDelay = randomBetween(
+              lastDelay.toNanos,
+              math.min(
+                maxDelay.toNanos,
+                minDelay.toNanos * (2L << attempt))).nano
+            scheduler.scheduleOnce(nextDelay)(retry(attempt + 1, nextDelay))
+          } else {
+            promise.failure(TimeoutException(s"$name failed after $maxAttempts attempt(s). Last error: ${e.getMessage}", e))
+          }
+        case Failure(e) =>
+          promise.failure(e)
+      }
+    }
+    retry(0, Duration.Zero)
+    promise.future
+  }
+
+  /**
+    * Retry a blocking call
+    * @param maxAttempts The maximum number of attempts before failing
+    * @param minDelay The minimum delay between invocations
+    * @param maxDelay The maximum delay between invocations
+    * @param retryOn A method that returns true for Throwables which should be retried
+    * @param f The method to transform
+    * @param scheduler The akka scheduler to execute on
+    * @param ctx The execution context to run the method on
+    * @tparam T The result type of 'f'
+    * @return The result of 'f', TimeoutException if 'f' failed 'maxAttempts' with retry-able exceptions
+    *         and the last exception that was thrown, or the last exception thrown if 'f' failed with a
+    *         non-retry-able exception.
+    */
+  def blocking[T](
+    name: String,
+    maxAttempts: Int = 5,
+    minDelay: FiniteDuration = 10.millis,
+    maxDelay: FiniteDuration = 1.second,
+    retryOn: RetryOnFn = defaultRetry)(f: => T)(implicit
+    scheduler: Scheduler,
+    ctx: ExecutionContext): Future[T] = {
+    apply(name, maxAttempts, minDelay, maxDelay, retryOn)(Future(blockingCall(f)))
+  }
+}

--- a/src/main/scala/org/apache/mesos/chronos/utils/TimeoutException.scala
+++ b/src/main/scala/org/apache/mesos/chronos/utils/TimeoutException.scala
@@ -1,0 +1,16 @@
+package org.apache.mesos.chronos.utils
+
+import java.util.concurrent.{ TimeoutException => JavaTimeoutException }
+
+/**
+  * Extension of a TimeoutException that allows a cause
+  */
+case class TimeoutException(reason: String, cause: Throwable) extends JavaTimeoutException(reason) {
+  @SuppressWarnings(Array("NullParameter"))
+  def this(reason: String) = this(reason, null)
+  override def getCause: Throwable = cause
+}
+
+object TimeoutException {
+  def apply(reason: String): TimeoutException = new TimeoutException(reason)
+}

--- a/src/test/scala/org/apache/mesos/chronos/ExitDisabledTest.scala
+++ b/src/test/scala/org/apache/mesos/chronos/ExitDisabledTest.scala
@@ -1,0 +1,88 @@
+package org.apache.mesos.chronos
+
+import java.security.Permission
+
+import akka.actor.{ ActorSystem, Scheduler }
+import org.apache.mesos.chronos.core.RichRuntime
+import org.specs2.specification.BeforeAfterAll
+
+import scala.collection.mutable
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.util.control.NonFatal
+
+import org.apache.mesos.chronos.utils.{RichLock, Lock, Retry}
+
+/**
+  * Mixin that will disable System.exit while the suite is running.
+  */
+trait ExitDisabledTest extends BeforeAfterAll {
+  private var securityManager = Option.empty[SecurityManager]
+  private var previousManager = Option.empty[SecurityManager]
+
+  override def beforeAll(): Unit = {
+    // intentionally initialize...
+    ExitDisabledTest.exitsCalled(_.size)
+    ExitDisabledTest.install()
+  }
+
+  override def afterAll(): Unit = {
+    ExitDisabledTest.remove()
+  }
+
+  def exitCalled(desiredCode: Int)(implicit system: ActorSystem, scheduler: Scheduler): Future[Boolean] = {
+    implicit val ctx = system.dispatcher
+    Retry.blocking("Check for exit", Int.MaxValue, 1.micro, RichRuntime.DefaultExitDelay.plus(1.second)) {
+      if (ExitDisabledTest.exitsCalled(_.contains(desiredCode))) {
+        ExitDisabledTest.exitsCalled(e => e.remove(e.indexOf(desiredCode)))
+        true
+      } else {
+        throw new Exception("Did not find desired exit code.")
+      }
+    }.recover {
+      case NonFatal(_) => false
+    }
+  }
+}
+
+object ExitDisabledTest {
+  private val exitsCalled = Lock(mutable.ArrayBuffer.empty[Int])
+  private val installLock = RichLock()
+  private var installCount = 0
+  private var previousManager = Option.empty[SecurityManager]
+
+  def install(): Unit = installLock {
+    if (installCount == 0) {
+      val newManager = new ExitDisabledSecurityManager()
+      previousManager = Option(System.getSecurityManager)
+      System.setSecurityManager(newManager)
+    }
+    installCount += 1
+  }
+
+  def remove(): Unit = installLock {
+    installCount -= 1
+    if (installCount == 0) {
+      System.setSecurityManager(previousManager.orNull)
+    }
+  }
+
+  private class ExitDisabledSecurityManager() extends SecurityManager {
+    override def checkExit(i: Int): Unit = {
+      exitsCalled(_ += i)
+      throw new IllegalStateException(s"Attempted to call exit with code: $i")
+    }
+
+    override def checkPermission(permission: Permission): Unit = {
+      if ("exitVM".equals(permission.getName)) {
+        throw new IllegalStateException("Attempted to call exitVM")
+      }
+    }
+
+    override def checkPermission(permission: Permission, o: scala.Any): Unit = {
+      if ("exitVM".equals(permission.getName)) {
+        throw new IllegalStateException("Attempted to call exitVM")
+      }
+    }
+  }
+}

--- a/src/test/scala/org/apache/mesos/chronos/core/RichRuntimeSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/core/RichRuntimeSpec.scala
@@ -1,0 +1,25 @@
+package org.apache.mesos.chronos.core
+
+import scala.concurrent.duration._
+import scala.concurrent._
+import org.specs2.mutable.SpecificationWithJUnit
+
+import akka.actor.ActorSystem
+import akka.actor.Scheduler
+import org.apache.mesos.chronos.ExitDisabledTest
+import org.joda.time.{DateTime, DateTimeZone, Period}
+import org.joda.time.format.{ISODateTimeFormat, ISOPeriodFormat}
+
+class RichRuntimeSpec extends SpecificationWithJUnit with ExitDisabledTest {
+
+  "RichRuntime.asyncExit" should {
+    "call exit" in {
+      import ExecutionContext.Implicits.global
+      implicit val system = ActorSystem()
+      implicit val scheduler = system.scheduler
+      RichRuntime().asyncExit(123)
+      Await.result(exitCalled(123), Duration.Inf) must_== true
+    }
+  }
+
+}

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/JobSchedulerElectionSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/JobSchedulerElectionSpec.scala
@@ -15,9 +15,10 @@ import org.junit.Assert.{assertFalse, assertTrue}
 import org.junit.Test
 import org.mockito.Mockito.doNothing
 import org.specs2.mock.Mockito
+import org.specs2.mutable.SpecificationWithJUnit
+import org.apache.mesos.chronos.ExitDisabledTest
 
-class JobSchedulerElectionSpec
-  extends Mockito {
+class JobSchedulerElectionSpec extends SpecificationWithJUnit with ExitDisabledTest with Mockito{
   var port = 8080
 
   @Test


### PR DESCRIPTION
To resolve the issues seen where state isn't completely cleared between
leadership elections, this takes the (admittedly heavy handed) approach
of exiting when the node loses its connection to ZK. This is obviously
under the assumption that the operator runs Chronos with an init system
to restart the process.

Heavily inspired and mostly copied from the equivalent change in
marathon: https://phabricator.mesosphere.com/D128