### PR TITLE
ensure cron runs in the context of UTC

### DIFF
--- a/src/test/scala/org/apache/mesos/chronos/AlternativeTimeZoneTest.scala
+++ b/src/test/scala/org/apache/mesos/chronos/AlternativeTimeZoneTest.scala
@@ -1,0 +1,15 @@
+package org.apache.mesos.chronos
+
+import java.util.TimeZone
+import org.specs2.specification.BeforeAfterEach
+
+trait AlternativeTimezoneTest extends BeforeAfterEach {
+   val defaultTimeZone = TimeZone.getDefault()
+   def before {
+     TimeZone.setDefault(TimeZone.getTimeZone("US/Pacific"))
+   }
+
+   def after {
+     TimeZone.setDefault(defaultTimeZone)
+   }
+}

--- a/src/test/scala/org/apache/mesos/chronos/schedule/CronParserSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/schedule/CronParserSpec.scala
@@ -1,10 +1,12 @@
 package org.apache.mesos.chronos.schedule
 
+import java.time.{ZonedDateTime, ZoneId}
+
+import org.apache.mesos.chronos.AlternativeTimezoneTest
+import org.joda.time.{DateTime, DateTimeZone, Period}
 import org.specs2.mutable.SpecificationWithJUnit
 
-import org.joda.time.{DateTime, DateTimeZone, Period}
-
-class CronParserSpec extends SpecificationWithJUnit{
+class CronParserSpec extends SpecificationWithJUnit {
  "Cron Parser should" in {
    "Parse Unix cron specifications to a next run schedule" in {
      val result = CronParser("01 * * * *")
@@ -22,4 +24,13 @@ class CronParserSpec extends SpecificationWithJUnit{
      result must beNone
    }
  }
+}
+
+class CronParserAltTZSpec extends SpecificationWithJUnit with AlternativeTimezoneTest {
+  "In US/Pacific Cron Parser should" in {
+   "Return the schedule in UTC" in {
+     val result = CronParser("0 18 * * *")
+     result.get.start.hourOfDay().get must_== 18
+   }
+  }
 }


### PR DESCRIPTION
closes #48 - when parsing the cron, make sure that we get the next execution in terms of UTC