### PR TITLE
support scheduleTimeZone for cron schedules

### DIFF
--- a/src/main/scala/org/apache/mesos/chronos/schedule/Parser.scala
+++ b/src/main/scala/org/apache/mesos/chronos/schedule/Parser.scala
@@ -42,7 +42,7 @@ object ISO8601Parser extends Parser{
 
 object CronParser extends Parser {
   private val log = Logger.getLogger(getClass.getName)
-  def apply(input: String, timeZoneStr: String = ""): Option[CronSchedule] = {
+  def apply(input: String, timeZoneStr: String = "UTC"): Option[CronSchedule] = {
     val unixCronParser =  new CronUtilsParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.UNIX))
     val cron = Try(unixCronParser.parse(input))
     val cronExpression = cron.map { ExecutionTime.forCron(_) }
@@ -50,7 +50,7 @@ object CronParser extends Parser {
     val dateForNextRun = cronExpression.map {
       //this gets a zoneddatetime for the next execution - force the timezone so that
       //we don't get into trouble when the system time != UTC
-      _.nextExecution(ZonedDateTime.now(ZoneId.of("UTC")))
+      _.nextExecution(ZonedDateTime.now(ZoneId.of(timeZoneStr)))
     }.map { zdt => new DateTime(zdt.toInstant().toEpochMilli(), DateTimeZone.forID("UTC")) }
 
     dateForNextRun match {

--- a/src/test/scala/org/apache/mesos/chronos/schedule/CronParserSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/schedule/CronParserSpec.scala
@@ -23,6 +23,10 @@ class CronParserSpec extends SpecificationWithJUnit {
      val result = CronParser("HI")
      result must beNone
    }
+   "Adjusts the timezone according to the scheduleTimeZone" in {
+     val result = CronParser("0 18 * * *", "US/Pacific")
+     result.get.start.hourOfDay().get must_== 2
+   }
  }
 }
 


### PR DESCRIPTION
up until now, cron has assumed UTC, so * 18 * * * will get scheduled at
18:00:00 UTC, even if your system time is set to an alternative TZ. This
change adds the same support for scheduleTimeZone as ISO8601 jobs have.
Everything internally is handled in UTC, and the job is adjusted as
parse time, making this a relatively simple change