### PR TITLE
ensure the tz info is kept between cron runs

### DIFF
--- a/src/main/scala/org/apache/mesos/chronos/schedule/Parser.scala
+++ b/src/main/scala/org/apache/mesos/chronos/schedule/Parser.scala
@@ -51,7 +51,12 @@ object CronParser extends Parser {
       //this gets a zoneddatetime for the next execution - force the timezone so that
       //we don't get into trouble when the system time != UTC
       _.nextExecution(ZonedDateTime.now(ZoneId.of(timeZoneStr)))
-    }.map { zdt => new DateTime(zdt.toInstant().toEpochMilli(), DateTimeZone.forID("UTC")) }
+    }.map {
+      //we use jodatime DateTime objects for actual scheduling, so we have to convert from
+      //a ZonedDateTime to a DateTime here.
+      zdt => new DateTime( zdt.toInstant().toEpochMilli(),
+      DateTimeZone.forTimeZone(TimeZone.getTimeZone(zdt.getZone())))
+    }
 
     dateForNextRun match {
       case Success(dateForNextRun) => Some(new CronSchedule(dateForNextRun, cron.get))

--- a/src/main/scala/org/apache/mesos/chronos/schedule/Schedule.scala
+++ b/src/main/scala/org/apache/mesos/chronos/schedule/Schedule.scala
@@ -1,6 +1,7 @@
 package org.apache.mesos.chronos.schedule
 
 import java.time.ZonedDateTime
+import java.util.TimeZone
 
 import com.cronutils.model.time.ExecutionTime
 import com.cronutils.model.Cron
@@ -35,7 +36,8 @@ object Nextable {
     def next(current: CronSchedule): Option[CronSchedule] = {
       val executionTime = ExecutionTime.forCron(current.cron)
       val dateForNextRun = executionTime.nextExecution(current.start.toGregorianCalendar().toZonedDateTime())
-      Some(new CronSchedule(new DateTime(dateForNextRun.toInstant().toEpochMilli(), DateTimeZone.forID("UTC")), current.cron))
+      val nextRun = new DateTime(dateForNextRun.toInstant().toEpochMilli(), DateTimeZone.forTimeZone(TimeZone.getTimeZone(dateForNextRun.getZone())))
+      Some(new CronSchedule(nextRun, current.cron))
     }
   }
   implicit object NextableISO8601 extends Nextable[ISO8601Schedule] {

--- a/src/test/scala/org/apache/mesos/chronos/AlternativeTimeZoneTest.scala
+++ b/src/test/scala/org/apache/mesos/chronos/AlternativeTimeZoneTest.scala
@@ -6,7 +6,7 @@ import org.specs2.specification.BeforeAfterEach
 trait AlternativeTimezoneTest extends BeforeAfterEach {
    val defaultTimeZone = TimeZone.getDefault()
    def before {
-     TimeZone.setDefault(TimeZone.getTimeZone("US/Pacific"))
+     TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"))
    }
 
    def after {

--- a/src/test/scala/org/apache/mesos/chronos/schedule/CronParserSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/schedule/CronParserSpec.scala
@@ -23,18 +23,20 @@ class CronParserSpec extends SpecificationWithJUnit {
      val result = CronParser("HI")
      result must beNone
    }
-   "Adjusts the timezone according to the scheduleTimeZone" in {
-     val result = CronParser("0 18 * * *", "US/Pacific")
-     result.get.start.hourOfDay().get must_== 2
+   "Creates a start time object with the correct time zone" in {
+     val result = CronParser("0 18 * * *", "America/Los_Angeles")
+     result.get.start.hourOfDay().get must_== 18
+     result.get.start.getZone.getID must_== "America/Los_Angeles"
    }
  }
 }
 
 class CronParserAltTZSpec extends SpecificationWithJUnit with AlternativeTimezoneTest {
   "In US/Pacific Cron Parser should" in {
-   "Return the schedule in UTC" in {
+   "Return a schedule with the correct TZ" in {
      val result = CronParser("0 18 * * *")
      result.get.start.hourOfDay().get must_== 18
+     result.get.start.getZone.getID == "UTC"
    }
   }
 }

--- a/src/test/scala/org/apache/mesos/chronos/schedule/ScheduleSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/schedule/ScheduleSpec.scala
@@ -32,5 +32,13 @@ class ScheduleSpec extends SpecificationWithJUnit{
       val inTenMinutes = NextableCron.next(inFiveMinutes.get)
       Minutes.minutesBetween(current.start.toDateTime, inTenMinutes.get.start.toDateTime) must_== Minutes.minutes(10)
     }
+
+    "Keep the timezone consistent" in {
+      val current = CronParser("0 18 * * *", "America/Los_Angeles").get
+      val nextRun = NextableCron.next(current)
+      nextRun must beSome
+      nextRun.get.start.getHourOfDay must_== current.start.getHourOfDay
+      nextRun.get.start.getZone.getID must_== "America/Los_Angeles"
+    }
   }
 }


### PR DESCRIPTION
This fixes a bug wherein the tz information was lost in the
NextableCron.next. Rather than trying to maintain UTC everywhere internally,
we can just use the fact that jodatime DateTime objects do keep TZ info,
and so we don't need to force UTC everywhere (jodatime does the heavy
lifting when comparing datetimes).