### PR TITLE
use the timezone for the job when computing 'now'

### DIFF
--- a/src/main/scala/org/apache/mesos/chronos/schedule/Parser.scala
+++ b/src/main/scala/org/apache/mesos/chronos/schedule/Parser.scala
@@ -33,7 +33,7 @@ object ISO8601Parser extends Parser{
       //TODO: deal with no period provided?
       val period: Period = ISOPeriodFormat.standard.parsePeriod(periodStr)
       val start: DateTime = startStr match {
-        case "" => DateTime.now(DateTimeZone.UTC)
+        case "" => DateTime.now(DateTimeZone.forID(timeZoneStr))
         case _ => DateTime.parse(startStr)
       }
       WithTimeZoneConsidered(new ISO8601Schedule(recurrences, start, period), timeZoneString)

--- a/src/test/scala/org/apache/mesos/chronos/schedule/ISO8601ParserSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/schedule/ISO8601ParserSpec.scala
@@ -32,5 +32,17 @@ class ISO8601ParserSpec extends SpecificationWithJUnit {
      val result = ISO8601Parser("R/2012-01-02T00:00:00.000Z/P1D", "foo")
      result must beNone
    }
+   
+   "Create a job 'now' when start time is omitted and timezone is UTC" in {
+     val result = ISO8601Parser("R//P1D", "UTC")
+     result must beSome
+     result.get.start.getHourOfDay must_== DateTime.now(DateTimeZone.UTC).getHourOfDay
+   }
+   
+   "Create a job 'now' when start time is omitted and timezone is not UTC" in {
+     val result = ISO8601Parser("R//P1D", "America/Los_Angeles")
+     result must beSome
+     result.get.start.getHourOfDay must_== DateTime.now(DateTimeZone.forID("America/Los_Angeles")).getHourOfDay
+   }
  }
 }


### PR DESCRIPTION
when a job omits the starttime, but does include a scheduleTimeZone, the
parser needs to consider the timezone when calculating now so it doesn't
get altered.

Fixes #54 