### PR TITLE
fix serialization of jobs with 0 recurrences

### DIFF
--- a/src/main/scala/org/apache/mesos/chronos/schedule/Schedule.scala
+++ b/src/main/scala/org/apache/mesos/chronos/schedule/Schedule.scala
@@ -15,7 +15,7 @@ sealed trait Schedule {
 
 final case class ISO8601Schedule(val recurrences: Long, val start: DateTime, val period: Period) extends Schedule {
   override def toString() = {
-    "R%s/%s/%s".format(if(recurrences > 0) recurrences.toString else "", ISODateTimeFormat.dateTime.print(start), period.toString())
+    "R%s/%s/%s".format(if(recurrences < 0) "" else recurrences.toString, ISODateTimeFormat.dateTime.print(start), period.toString())
   }
 }
 

--- a/src/test/scala/org/apache/mesos/chronos/schedule/ScheduleSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/schedule/ScheduleSpec.scala
@@ -3,10 +3,24 @@ package org.apache.mesos.chronos.schedule
 import org.specs2.mutable.SpecificationWithJUnit
 
 import org.joda.time.{DateTime, DateTimeZone, Period, Minutes}
+import org.joda.time.format.ISODateTimeFormat
 import org.apache.mesos.chronos.schedule.Nextable.NextableCron
 import org.apache.mesos.chronos.schedule.Nextable.NextableISO8601
 
 class ScheduleSpec extends SpecificationWithJUnit{
+
+  "ISO8601Schedule" should {
+    "Encode repeat string correctly for unlimited jobs" in {
+      val now = DateTime.now
+      val job = new ISO8601Schedule(-1, now, Period.hours(1))
+      job.toString must_== "R/%s/PT1H".format(ISODateTimeFormat.dateTime.print(now))
+    }
+    "Encode repeat string correctly for 0 jobs" in {
+      val now = DateTime.now
+      val job = new ISO8601Schedule(0, now, Period.hours(1))
+      job.toString must_== "R0/%s/PT1H".format(ISODateTimeFormat.dateTime.print(now))
+    }
+  }
   "NextableISO8601" should {
     "Reduce recurrences with each iteration" in {
       val current = ISO8601Parser("R2/2012-01-02T00:00:01.000Z/P1M").get


### PR DESCRIPTION
fixes a bug causing R0 to be serialized as 'R' which caused Chronos to
consider to job to have unlimited retries when it loaded it from ZK
on start

This is what caused the problems with the job created with ``paasta rerun`` this morning.
After the job ran, there was a leader election, causing the new leader to parse the job out of ZK.
The erroneous serializing caused chronos to read the job with unlimited retries.