### PR TITLE
Recover failed launches

### DIFF
--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/JobScheduler.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/JobScheduler.scala
@@ -327,7 +327,7 @@ class JobScheduler @Inject()(val scheduleHorizon: Period,
   }
 
   private def getNewSuccessfulJob(job: BaseJob): BaseJob = {
-    log.info(s"Marking job {job.name} as success")
+    log.info("Marking job %s as success".format(job.name))
     val newJob = job match {
       case job: ScheduleBasedJob =>
         job.copy(successCount = job.successCount + 1,

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/mesos/MesosJobFramework.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/mesos/MesosJobFramework.scala
@@ -17,6 +17,10 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.collection.mutable.{Buffer, HashMap, HashSet}
 
+case class ChronosTask(val slaveId: String, val taskStatus: Option[TaskStatus])
+
+
+
 /**
  * Provides the interface to chronos. Receives callbacks from chronos when resources are offered, declined etc.
  * @author Florian Leibert (flo@leibert.de)
@@ -339,14 +343,6 @@ class MesosJobFramework @Inject()(
       "cpus: " + this.cpus + " mem: " + this.mem + " disk: " + this.disk
     }
   }
-
-  private class ChronosTask(val slaveId: String,
-                            var taskStatus: Option[TaskStatus] = None) {
-    override def toString: String = {
-      s"slaveId=$slaveId, taskStatus=${taskStatus.getOrElse("none").toString}"
-    }
-  }
-
   object Resources {
     def apply(offer: Offer): Resources = {
       val resources = offer.getResourcesList.asScala.filter(r => !r.hasRole || r.getRole == "*" || r.getRole == config.mesosRole())

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/mesos/MesosJobFramework.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/mesos/MesosJobFramework.scala
@@ -45,7 +45,7 @@ class MesosJobFramework @Inject()(
 
     log.info("Registered with ID: " + frameworkID.getValue)
     log.info("Master info:" + masterInfo.toString)
-    log.info("RUNNING TASKS: %s".format(runningTasks.toString))
+    log.info("Running Tasks on registration: %s".format(runningTasks.toString))
     frameworkIdUtil.store(frameworkID)
     mesosOfferReviver.reviveOffers()
   }
@@ -278,7 +278,7 @@ class MesosJobFramework @Inject()(
 
   @Override
   def slaveLost(schedulerDriver: SchedulerDriver, slaveID: SlaveID) {
-    log.warning("Slave lost")
+    log.warning("Slave %s lost".format(slaveID.getValue))
 
     // Remove any running jobs from this slave
     val jobs = runningTasks.filter {
@@ -290,7 +290,7 @@ class MesosJobFramework @Inject()(
 
   @Override
   def executorLost(schedulerDriver: SchedulerDriver, executorID: ExecutorID, slaveID: SlaveID, status: Int) {
-    log.info("Executor lost")
+    log.warning("Executor %s on slave %s lost".format(executorID.getValue, slaveID.getValue))
   }
 
   @Override

--- a/src/main/scala/org/apache/mesos/chronos/utils/JobDeserializer.scala
+++ b/src/main/scala/org/apache/mesos/chronos/utils/JobDeserializer.scala
@@ -7,12 +7,12 @@ import org.apache.mesos.chronos.scheduler.jobs._
 import org.apache.mesos.chronos.scheduler.jobs.constraints._
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.node.ObjectNode
-import com.fasterxml.jackson.databind.{DeserializationContext, JsonDeserializer, JsonNode}
+import com.fasterxml.jackson.databind.{ DeserializationContext, JsonDeserializer, JsonNode }
 import org.joda.time.Period
 
 import scala.collection.JavaConversions._
 import scala.util.Try
-import org.apache.mesos.chronos.schedule.{ParserForSchedule,ISO8601Parser}
+import org.apache.mesos.chronos.schedule.{ ParserForSchedule, ISO8601Parser }
 
 object JobDeserializer {
   var config: SchedulerConfiguration = _
@@ -99,17 +99,17 @@ class JobDeserializer extends JsonDeserializer[BaseJob] {
       else ""
 
     val cpus =
-      if (node.has("cpus") && node.get("cpus") != null && node.get("cpus").asDouble != 0) node.get("cpus").asDouble
+      if (node.has("cpus") && node.get("cpus") != null) node.get("cpus").asDouble
       else if (JobDeserializer.config != null) JobDeserializer.config.mesosTaskCpu()
       else 0
 
     val disk =
-      if (node.has("disk") && node.get("disk") != null && node.get("disk").asDouble != 0) node.get("disk").asDouble
+      if (node.has("disk") && node.get("disk") != null) node.get("disk").asDouble
       else if (JobDeserializer.config != null) JobDeserializer.config.mesosTaskDisk()
       else 0
 
     val mem =
-      if (node.has("mem") && node.get("mem") != null && node.get("mem").asDouble != 0) node.get("mem").asDouble
+      if (node.has("mem") && node.get("mem") != null) node.get("mem").asDouble
       else if (JobDeserializer.config != null) JobDeserializer.config.mesosTaskMem()
       else 0
 
@@ -193,7 +193,7 @@ class JobDeserializer extends JsonDeserializer[BaseJob] {
       if (containerNode.has("parameters")) {
         containerNode.get("parameters").elements().map {
           case node: ObjectNode =>
-          Parameter(node.get("key").asText(), node.get("value").asText)
+            Parameter(node.get("key").asText(), node.get("value").asText)
         }.foreach(parameters.add)
       }
 
@@ -240,13 +240,13 @@ class JobDeserializer extends JsonDeserializer[BaseJob] {
         executorFlags = executorFlags, taskInfoData = taskInfoData, retries = retries, owner = owner, ownerName = ownerName,
         description = description, lastError = lastError, lastSuccess = lastSuccess, async = async,
         cpus = cpus, disk = disk, mem = mem, disabled = disabled,
-        errorsSinceLastSuccess = errorsSinceLastSuccess, fetch = fetch, uris = uris,  highPriority = highPriority,
+        errorsSinceLastSuccess = errorsSinceLastSuccess, fetch = fetch, uris = uris, highPriority = highPriority,
         runAsUser = runAsUser, container = container, scheduleTimeZone = scheduleTimeZone,
         environmentVariables = environmentVariables, shell = shell, arguments = arguments, softError = softError,
         dataProcessingJobType = dataProcessingJobType, constraints = constraints))
-       deserializedJob match {
+      deserializedJob match {
         case Some(job) => job
-        case None => throw ctxt.mappingException("Couldn't parse schedule %s with timezonestring %s for job %s".format(node.get("schedule").asText, scheduleTimeZone, name))
+        case None      => throw ctxt.mappingException("Couldn't parse schedule %s with timezonestring %s for job %s".format(node.get("schedule").asText, scheduleTimeZone, name))
       }
     } else {
       /* schedule now */
@@ -254,13 +254,13 @@ class JobDeserializer extends JsonDeserializer[BaseJob] {
         errorCount = errorCount, executor = executor, executorFlags = executorFlags, taskInfoData = taskInfoData, retries = retries, owner = owner,
         ownerName = ownerName, description = description, lastError = lastError, lastSuccess = lastSuccess,
         async = async, cpus = cpus, disk = disk, mem = mem, disabled = disabled,
-        errorsSinceLastSuccess = errorsSinceLastSuccess, fetch = fetch, uris = uris,  highPriority = highPriority,
+        errorsSinceLastSuccess = errorsSinceLastSuccess, fetch = fetch, uris = uris, highPriority = highPriority,
         runAsUser = runAsUser, container = container, environmentVariables = environmentVariables, shell = shell,
         arguments = arguments, softError = softError, dataProcessingJobType = dataProcessingJobType,
         constraints = constraints))
       job match {
         case Some(job) => job
-        case None => throw ctxt.mappingException("Couldn't parse schedule %s with timezonestring %s".format(node.get("schedule").asText, "UTC"))
+        case None      => throw ctxt.mappingException("Couldn't parse schedule %s with timezonestring %s".format(node.get("schedule").asText, "UTC"))
       }
     }
   }

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/api/SerDeTest.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/api/SerDeTest.scala
@@ -1,9 +1,10 @@
 package org.apache.mesos.chronos.scheduler.api
 
-import org.apache.mesos.chronos.scheduler.jobs.constraints.{LikeConstraint, EqualsConstraint, UnlikeConstraint}
-import org.apache.mesos.chronos.scheduler.jobs.{DependencyBasedJob, DockerContainer, EnvironmentVariable, ScheduleBasedJob, _}
-import org.apache.mesos.chronos.schedule.{CronSchedule, ISO8601Parser,ISO8601Schedule}
-import org.apache.mesos.chronos.utils.{JobDeserializer, JobSerializer}
+import org.apache.mesos.chronos.scheduler.jobs.constraints.{ LikeConstraint, EqualsConstraint, UnlikeConstraint }
+import org.apache.mesos.chronos.scheduler.jobs.{ DependencyBasedJob, DockerContainer, EnvironmentVariable, ScheduleBasedJob, _ }
+import org.apache.mesos.chronos.schedule.{ CronSchedule, ISO8601Parser, ISO8601Schedule }
+import org.apache.mesos.chronos.utils.{ JobDeserializer, JobSerializer }
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.module.SimpleModule
 import org.joda.time.Minutes
@@ -18,16 +19,15 @@ class SerDeTest extends SpecificationWithJUnit {
       mod.addSerializer(classOf[BaseJob], new JobSerializer)
       mod.addDeserializer(classOf[BaseJob], new JobDeserializer)
       objectMapper.registerModule(mod)
+      objectMapper.registerModule(DefaultScalaModule)
 
       val environmentVariables = Seq(
         EnvironmentVariable("FOO", "BAR"),
-        EnvironmentVariable("AAAA", "BBBB")
-      )
+        EnvironmentVariable("AAAA", "BBBB"))
 
       val volumes = Seq(
         Volume(Option("/host/dir"), "container/dir", Option(VolumeMode.RO)),
-        Volume(None, "container/dir", None)
-      )
+        Volume(None, "container/dir", None))
 
       val forcePullImage = false
 
@@ -36,14 +36,12 @@ class SerDeTest extends SpecificationWithJUnit {
       val container = DockerContainer("dockerImage", volumes, parameters, NetworkMode.BRIDGE, forcePullImage)
 
       val arguments = Seq(
-        "-testOne"
-      )
+        "-testOne")
 
       val constraints = Seq(
         EqualsConstraint("rack", "rack-1"),
         LikeConstraint("rack", "rack-[1-3]"),
-        UnlikeConstraint("host", "foo")
-      )
+        UnlikeConstraint("host", "foo"))
 
       val fetch = Seq(Fetch("https://mesos.github.io/chronos/", true, false, true))
 
@@ -64,16 +62,15 @@ class SerDeTest extends SpecificationWithJUnit {
       mod.addSerializer(classOf[BaseJob], new JobSerializer)
       mod.addDeserializer(classOf[BaseJob], new JobDeserializer)
       objectMapper.registerModule(mod)
+      objectMapper.registerModule(DefaultScalaModule)
 
       val environmentVariables = Seq(
         EnvironmentVariable("FOO", "BAR"),
-        EnvironmentVariable("AAAA", "BBBB")
-      )
+        EnvironmentVariable("AAAA", "BBBB"))
 
       val volumes = Seq(
         Volume(Option("/host/dir"), "container/dir", Option(VolumeMode.RW)),
-        Volume(None, "container/dir", None)
-      )
+        Volume(None, "container/dir", None))
 
       val forcePullImage = true
       var parameters = scala.collection.mutable.ListBuffer[Parameter]()
@@ -81,17 +78,15 @@ class SerDeTest extends SpecificationWithJUnit {
       val container = DockerContainer("dockerImage", volumes, parameters, NetworkMode.HOST, forcePullImage)
 
       val arguments = Seq(
-        "-testOne"
-      )
+        "-testOne")
 
       val constraints = Seq(
         EqualsConstraint("rack", "rack-1"),
         LikeConstraint("rack", "rack-[1-3]"),
-        UnlikeConstraint("host", "foo")
-      )
+        UnlikeConstraint("host", "foo"))
 
       val fetch = Seq(Fetch("https://mesos.github.io/chronos/", true, false, true))
-      
+
       val schedule = ISO8601Parser("R1/2012-10-01T05:52:00Z/PT30S").get
 
       val a = new ScheduleBasedJob(schedule, "A", "noop", Minutes.minutes(5).toPeriod, 10L, 20L,

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/mesos/MesosJobFrameworkSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/mesos/MesosJobFrameworkSpec.scala
@@ -1,15 +1,18 @@
 package org.apache.mesos.chronos.scheduler.mesos
 
 import java.nio.charset.StandardCharsets
-import mesosphere.mesos.protos._
+import java.util.Collection
 import mesosphere.mesos.util.FrameworkIdUtil
+import mesosphere.mesos.protos.{ ScalarResource, Resource }
 import com.google.common.cache.Cache
-import org.apache.mesos.Protos.Offer
 import org.apache.mesos.chronos.ChronosTestHelper._
-import org.apache.mesos.chronos.scheduler.jobs.{ BaseJob, JobScheduler, TaskManager }
+import org.apache.mesos.chronos.scheduler.jobs.{ ScheduleBasedJob, BaseJob, JobScheduler, TaskManager }
+import org.apache.mesos.chronos.schedule.ISO8601Parser
 import org.apache.mesos.chronos.scheduler.state.PersistenceStore
-import org.apache.mesos.{ Protos, SchedulerDriver }
+import org.apache.mesos.Protos
+import org.apache.mesos.SchedulerDriver
 import org.mockito.Mockito._
+import org.mockito.Matchers
 import org.specs2.mock.Mockito
 import org.specs2.mutable.SpecificationWithJUnit
 
@@ -71,14 +74,16 @@ class MesosJobFrameworkSpec extends SpecificationWithJUnit with Mockito {
           mock[MesosTaskBuilder],
           mock[MesosOfferReviver]))
 
-      val tasks = mutable.Buffer[(String, BaseJob, Offer)]()
+      val tasks = mutable.Buffer[(String, BaseJob, Protos.Offer)]()
       doReturn(tasks).when(mesosJobFramework).generateLaunchableTasks(any)
       doNothing.when(mesosJobFramework).reconcile(any)
 
-      val offer: Offer = makeBasicOffer
+      val offer = makeBasicOffer
       mesosJobFramework.resourceOffers(mock[SchedulerDriver], Seq[Protos.Offer](offer).asJava)
 
-      there was one (schedulerDriver).declineOffer(OfferID("1"), Protos.Filters.getDefaultInstance)
+      there was one(schedulerDriver).declineOffer(
+        Protos.OfferID.newBuilder().setValue("1").build(),
+        Protos.Filters.getDefaultInstance)
     }
 
     "Reject unused offers with default RefuseSeconds if --decline_offer_duration is not set" in {
@@ -100,14 +105,16 @@ class MesosJobFrameworkSpec extends SpecificationWithJUnit with Mockito {
           mock[MesosTaskBuilder],
           mock[MesosOfferReviver]))
 
-      val tasks = mutable.Buffer[(String, BaseJob, Offer)]()
+      val tasks = mutable.Buffer[(String, BaseJob, Protos.Offer)]()
       doReturn(tasks).when(mesosJobFramework).generateLaunchableTasks(any)
       doNothing.when(mesosJobFramework).reconcile(any)
 
-      val offer: Offer = makeBasicOffer
+      val offer = makeBasicOffer
       mesosJobFramework.resourceOffers(mock[SchedulerDriver], Seq[Protos.Offer](offer).asJava)
 
-      there was one (schedulerDriver).declineOffer(OfferID("1"), Protos.Filters.getDefaultInstance)
+      there was one(schedulerDriver).declineOffer(
+        Protos.OfferID.newBuilder.setValue("1").build,
+        Protos.Filters.getDefaultInstance)
     }
   }
 
@@ -130,24 +137,25 @@ class MesosJobFrameworkSpec extends SpecificationWithJUnit with Mockito {
         mock[MesosTaskBuilder],
         mock[MesosOfferReviver]))
 
-    val tasks = mutable.Buffer[(String, BaseJob, Offer)]()
+    val tasks = mutable.Buffer[(String, BaseJob, Protos.Offer)]()
     doReturn(tasks).when(mesosJobFramework).generateLaunchableTasks(any)
     doNothing.when(mesosJobFramework).reconcile(any)
 
-    val offer: Offer = makeBasicOffer
+    val offer = makeBasicOffer
     mesosJobFramework.resourceOffers(mock[SchedulerDriver], Seq[Protos.Offer](offer).asJava)
 
     val filters = Protos.Filters.newBuilder().setRefuseSeconds(3).build()
-    there was one (schedulerDriver).declineOffer(OfferID("1"), filters)
+    there was one(schedulerDriver).declineOffer(
+      Protos.OfferID.newBuilder.setValue("1").build,
+      filters)
   }
 
-  private[this] def makeBasicOffer: Offer = {
+  private[this] def makeBasicOffer: Protos.Offer = {
     import mesosphere.mesos.protos.Implicits._
-
     Protos.Offer.newBuilder()
-      .setId(OfferID("1"))
-      .setFrameworkId(FrameworkID("chronos"))
-      .setSlaveId(SlaveID("slave0"))
+      .setId(Protos.OfferID.newBuilder().setValue("1").build())
+      .setFrameworkId(Protos.FrameworkID.newBuilder().setValue("chronos"))
+      .setSlaveId(Protos.SlaveID.newBuilder.setValue("slave0").build)
       .setHostname("localhost")
       .addResources(ScalarResource(Resource.CPUS, 1, "*"))
       .addResources(ScalarResource(Resource.MEM, 100, "*"))
@@ -214,7 +222,7 @@ class MesosJobFrameworkSpec extends SpecificationWithJUnit with Mockito {
         mock[MesosOfferReviver]))
     val status = Protos.TaskStatus.newBuilder()
       .setTaskId(Protos.TaskID.newBuilder()
-      .setValue("mytask"))
+        .setValue("mytask"))
       .setState(Protos.TaskState.TASK_LOST)
       .build()
 
@@ -228,7 +236,7 @@ class MesosJobFrameworkSpec extends SpecificationWithJUnit with Mockito {
 
     val taskManager = mock[TaskManager]
     val persistenceStore = mock[PersistenceStore]
-    val fakeTasks = collection.immutable.HashMap("ct:0000:1:foo" -> "foo".getBytes(StandardCharsets.UTF_8) )
+    val fakeTasks = collection.immutable.HashMap("ct:0000:1:foo" -> "foo".getBytes(StandardCharsets.UTF_8))
     persistenceStore.getTasks returns fakeTasks
     taskManager.persistenceStore returns persistenceStore
     val jobScheduler = mock[JobScheduler]
@@ -252,11 +260,54 @@ class MesosJobFrameworkSpec extends SpecificationWithJUnit with Mockito {
         mock[MesosTaskBuilder],
         mock[MesosOfferReviver]))
     val status = Protos.TaskStatus.newBuilder()
-      .setTaskId(Protos.TaskID.newBuilder()
-      .setValue("ct:0000:1:foo"))
+      .setTaskId(
+        Protos.TaskID.newBuilder()
+          .setValue("ct:0000:1:foo")
+          .build())
       .setState(Protos.TaskState.TASK_LOST)
       .build()
     mesosJobFramework.statusUpdate(schedulerDriver, status)
     there was one(jobScheduler).handleFailedTask(status)
+  }
+
+  "Set initial status of a task to TASK_RUNNING" in {
+    import mesosphere.mesos.protos.Implicits._
+    import scala.collection.JavaConverters._
+
+    val fakeOffer = Protos.Offer.newBuilder().setSlaveId(
+      Protos.SlaveID.newBuilder().setValue("slave1")).setId(
+        Protos.OfferID.newBuilder().setValue("offer")).setFrameworkId(
+          Protos.FrameworkID.newBuilder().setValue("framework")).setHostname("slave1").build()
+
+    val fakeJob = new ScheduleBasedJob(
+      schedule = ISO8601Parser("R1/2012-01-01T00:02:00.000Z/PT1M").get,
+      name = "foo",
+      command = "")
+
+    val fakeTasks = mutable.Buffer[(String, BaseJob, Protos.Offer)]()
+    fakeTasks.append(("ct:1454467003926:0:test2Execution:run", fakeJob, fakeOffer))
+
+    val mesosDriverFactory = mock[MesosDriverFactory]
+    val schedulerDriver = mock[SchedulerDriver]
+    mesosDriverFactory.get().returns(schedulerDriver)
+    schedulerDriver.launchTasks(
+      Matchers.any[Collection[Protos.OfferID]],
+      Matchers.any[Collection[Protos.TaskInfo]]) returns (Protos.Status.DRIVER_RUNNING)
+
+    val mesosJobFramework = spy(
+      new MesosJobFramework(
+        mesosDriverFactory,
+        mock[JobScheduler],
+        mock[TaskManager],
+        makeConfig(),
+        mock[FrameworkIdUtil],
+        new MesosTaskBuilder(makeConfig()),
+        mock[MesosOfferReviver]))
+
+    mesosJobFramework.launchTasks(fakeTasks)
+    mesosJobFramework.runningTasks.get("foo") must beSome
+    mesosJobFramework.runningTasks.get("foo").get.slaveId mustEqual ("slave1")
+    mesosJobFramework.runningTasks.get("foo").get.taskStatus must beSome
+    mesosJobFramework.runningTasks.get("foo").get.taskStatus.get.getState mustEqual (Protos.TaskState.TASK_RUNNING)
   }
 }


### PR DESCRIPTION
I'm going to pair this with reducing the ``reconcileInterval`` on our Chronos masters so that the problem is caught a bit quicker.

This is a step towards solving internal PAASTA-8202, and should mean that we catch tasks that are never launched by Mesos.