### PR TITLE
when deserializing, 0 is OK for disk, cpus and mem

### DIFF
--- a/src/main/scala/org/apache/mesos/chronos/utils/JobDeserializer.scala
+++ b/src/main/scala/org/apache/mesos/chronos/utils/JobDeserializer.scala
@@ -7,12 +7,12 @@ import org.apache.mesos.chronos.scheduler.jobs._
 import org.apache.mesos.chronos.scheduler.jobs.constraints._
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.node.ObjectNode
-import com.fasterxml.jackson.databind.{DeserializationContext, JsonDeserializer, JsonNode}
+import com.fasterxml.jackson.databind.{ DeserializationContext, JsonDeserializer, JsonNode }
 import org.joda.time.Period
 
 import scala.collection.JavaConversions._
 import scala.util.Try
-import org.apache.mesos.chronos.schedule.{ParserForSchedule,ISO8601Parser}
+import org.apache.mesos.chronos.schedule.{ ParserForSchedule, ISO8601Parser }
 
 object JobDeserializer {
   var config: SchedulerConfiguration = _
@@ -99,17 +99,17 @@ class JobDeserializer extends JsonDeserializer[BaseJob] {
       else ""
 
     val cpus =
-      if (node.has("cpus") && node.get("cpus") != null && node.get("cpus").asDouble != 0) node.get("cpus").asDouble
+      if (node.has("cpus") && node.get("cpus") != null) node.get("cpus").asDouble
       else if (JobDeserializer.config != null) JobDeserializer.config.mesosTaskCpu()
       else 0
 
     val disk =
-      if (node.has("disk") && node.get("disk") != null && node.get("disk").asDouble != 0) node.get("disk").asDouble
+      if (node.has("disk") && node.get("disk") != null) node.get("disk").asDouble
       else if (JobDeserializer.config != null) JobDeserializer.config.mesosTaskDisk()
       else 0
 
     val mem =
-      if (node.has("mem") && node.get("mem") != null && node.get("mem").asDouble != 0) node.get("mem").asDouble
+      if (node.has("mem") && node.get("mem") != null) node.get("mem").asDouble
       else if (JobDeserializer.config != null) JobDeserializer.config.mesosTaskMem()
       else 0
 
@@ -193,7 +193,7 @@ class JobDeserializer extends JsonDeserializer[BaseJob] {
       if (containerNode.has("parameters")) {
         containerNode.get("parameters").elements().map {
           case node: ObjectNode =>
-          Parameter(node.get("key").asText(), node.get("value").asText)
+            Parameter(node.get("key").asText(), node.get("value").asText)
         }.foreach(parameters.add)
       }
 
@@ -240,13 +240,13 @@ class JobDeserializer extends JsonDeserializer[BaseJob] {
         executorFlags = executorFlags, taskInfoData = taskInfoData, retries = retries, owner = owner, ownerName = ownerName,
         description = description, lastError = lastError, lastSuccess = lastSuccess, async = async,
         cpus = cpus, disk = disk, mem = mem, disabled = disabled,
-        errorsSinceLastSuccess = errorsSinceLastSuccess, fetch = fetch, uris = uris,  highPriority = highPriority,
+        errorsSinceLastSuccess = errorsSinceLastSuccess, fetch = fetch, uris = uris, highPriority = highPriority,
         runAsUser = runAsUser, container = container, scheduleTimeZone = scheduleTimeZone,
         environmentVariables = environmentVariables, shell = shell, arguments = arguments, softError = softError,
         dataProcessingJobType = dataProcessingJobType, constraints = constraints))
-       deserializedJob match {
+      deserializedJob match {
         case Some(job) => job
-        case None => throw ctxt.mappingException("Couldn't parse schedule %s with timezonestring %s for job %s".format(node.get("schedule").asText, scheduleTimeZone, name))
+        case None      => throw ctxt.mappingException("Couldn't parse schedule %s with timezonestring %s for job %s".format(node.get("schedule").asText, scheduleTimeZone, name))
       }
     } else {
       /* schedule now */
@@ -254,13 +254,13 @@ class JobDeserializer extends JsonDeserializer[BaseJob] {
         errorCount = errorCount, executor = executor, executorFlags = executorFlags, taskInfoData = taskInfoData, retries = retries, owner = owner,
         ownerName = ownerName, description = description, lastError = lastError, lastSuccess = lastSuccess,
         async = async, cpus = cpus, disk = disk, mem = mem, disabled = disabled,
-        errorsSinceLastSuccess = errorsSinceLastSuccess, fetch = fetch, uris = uris,  highPriority = highPriority,
+        errorsSinceLastSuccess = errorsSinceLastSuccess, fetch = fetch, uris = uris, highPriority = highPriority,
         runAsUser = runAsUser, container = container, environmentVariables = environmentVariables, shell = shell,
         arguments = arguments, softError = softError, dataProcessingJobType = dataProcessingJobType,
         constraints = constraints))
       job match {
         case Some(job) => job
-        case None => throw ctxt.mappingException("Couldn't parse schedule %s with timezonestring %s".format(node.get("schedule").asText, "UTC"))
+        case None      => throw ctxt.mappingException("Couldn't parse schedule %s with timezonestring %s".format(node.get("schedule").asText, "UTC"))
       }
     }
   }

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/api/SerDeTest.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/api/SerDeTest.scala
@@ -1,9 +1,10 @@
 package org.apache.mesos.chronos.scheduler.api
 
-import org.apache.mesos.chronos.scheduler.jobs.constraints.{LikeConstraint, EqualsConstraint, UnlikeConstraint}
-import org.apache.mesos.chronos.scheduler.jobs.{DependencyBasedJob, DockerContainer, EnvironmentVariable, ScheduleBasedJob, _}
-import org.apache.mesos.chronos.schedule.{CronSchedule, ISO8601Parser,ISO8601Schedule}
-import org.apache.mesos.chronos.utils.{JobDeserializer, JobSerializer}
+import org.apache.mesos.chronos.scheduler.jobs.constraints.{ LikeConstraint, EqualsConstraint, UnlikeConstraint }
+import org.apache.mesos.chronos.scheduler.jobs.{ DependencyBasedJob, DockerContainer, EnvironmentVariable, ScheduleBasedJob, _ }
+import org.apache.mesos.chronos.schedule.{ CronSchedule, ISO8601Parser, ISO8601Schedule }
+import org.apache.mesos.chronos.utils.{ JobDeserializer, JobSerializer }
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.module.SimpleModule
 import org.joda.time.Minutes
@@ -18,16 +19,15 @@ class SerDeTest extends SpecificationWithJUnit {
       mod.addSerializer(classOf[BaseJob], new JobSerializer)
       mod.addDeserializer(classOf[BaseJob], new JobDeserializer)
       objectMapper.registerModule(mod)
+      objectMapper.registerModule(DefaultScalaModule)
 
       val environmentVariables = Seq(
         EnvironmentVariable("FOO", "BAR"),
-        EnvironmentVariable("AAAA", "BBBB")
-      )
+        EnvironmentVariable("AAAA", "BBBB"))
 
       val volumes = Seq(
         Volume(Option("/host/dir"), "container/dir", Option(VolumeMode.RO)),
-        Volume(None, "container/dir", None)
-      )
+        Volume(None, "container/dir", None))
 
       val forcePullImage = false
 
@@ -36,14 +36,12 @@ class SerDeTest extends SpecificationWithJUnit {
       val container = DockerContainer("dockerImage", volumes, parameters, NetworkMode.BRIDGE, forcePullImage)
 
       val arguments = Seq(
-        "-testOne"
-      )
+        "-testOne")
 
       val constraints = Seq(
         EqualsConstraint("rack", "rack-1"),
         LikeConstraint("rack", "rack-[1-3]"),
-        UnlikeConstraint("host", "foo")
-      )
+        UnlikeConstraint("host", "foo"))
 
       val fetch = Seq(Fetch("https://mesos.github.io/chronos/", true, false, true))
 
@@ -64,16 +62,15 @@ class SerDeTest extends SpecificationWithJUnit {
       mod.addSerializer(classOf[BaseJob], new JobSerializer)
       mod.addDeserializer(classOf[BaseJob], new JobDeserializer)
       objectMapper.registerModule(mod)
+      objectMapper.registerModule(DefaultScalaModule)
 
       val environmentVariables = Seq(
         EnvironmentVariable("FOO", "BAR"),
-        EnvironmentVariable("AAAA", "BBBB")
-      )
+        EnvironmentVariable("AAAA", "BBBB"))
 
       val volumes = Seq(
         Volume(Option("/host/dir"), "container/dir", Option(VolumeMode.RW)),
-        Volume(None, "container/dir", None)
-      )
+        Volume(None, "container/dir", None))
 
       val forcePullImage = true
       var parameters = scala.collection.mutable.ListBuffer[Parameter]()
@@ -81,17 +78,15 @@ class SerDeTest extends SpecificationWithJUnit {
       val container = DockerContainer("dockerImage", volumes, parameters, NetworkMode.HOST, forcePullImage)
 
       val arguments = Seq(
-        "-testOne"
-      )
+        "-testOne")
 
       val constraints = Seq(
         EqualsConstraint("rack", "rack-1"),
         LikeConstraint("rack", "rack-[1-3]"),
-        UnlikeConstraint("host", "foo")
-      )
+        UnlikeConstraint("host", "foo"))
 
       val fetch = Seq(Fetch("https://mesos.github.io/chronos/", true, false, true))
-      
+
       val schedule = ISO8601Parser("R1/2012-10-01T05:52:00Z/PT30S").get
 
       val a = new ScheduleBasedJob(schedule, "A", "noop", Minutes.minutes(5).toPeriod, 10L, 20L,


### PR DESCRIPTION
This was causing the serializer and deserializer tests to be flaky. I
don't understand how they *ever* pass now that I see the problem? When
deserializing, we were using ``mesos_task_cpu``, ``mesos_task_disk`` and ``mesos_task_mem`` 
as values for cpu, disk and mem respectively if either the value was not set, or it
was set to 0. However, the default value for cpus, disk and mem in the constructor
of BaseJob is 0; thus, when a BaseJob with the default constructor value
for cpu and disk was serialized, that value would be changed to 0.1
upon deserialization.

The solution is to respect 0 as an OK value when deserializing.

closes #56