### PR TITLE
be consistent on how to key startupTimers

### DIFF
--- a/src/main/scala/org/apache/mesos/chronos/scheduler/mesos/MesosJobFramework.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/mesos/MesosJobFramework.scala
@@ -218,14 +218,14 @@ class MesosJobFramework @Inject() (
     }
   }
 
-  def cancelKilledStatusUpdate(jobName: String): Unit = {
-    startupTimers.remove(jobName) map {
+  def cancelKilledStatusUpdate(keyForTimer: String): Unit = {
+    startupTimers.remove(keyForTimer) map {
       // http://doc.akka.io/docs/akka/current/scala/scheduler.html#
       // The_Cancellable_interface does not abort the execution of the task,
       // if it had already been started
       log.info(
-        "Got status update for task %s, cancelling it's startup timer".
-          format(jobName))
+        "Got status update for task %s, cancelling it's startup timer"
+          .format(keyForTimer))
       _.cancel
     }
   }
@@ -277,7 +277,7 @@ class MesosJobFramework @Inject() (
 
             val cancellable = scheduleKilledStatusFromInitial(
               initialStatus, task._2.startupTimeout)
-            startupTimers += (task._2.name -> cancellable)
+            startupTimers += (task._1 -> cancellable)
 
             log.info(
               "Attempted launch of %s - waiting for StatusUpdate confirmation.".
@@ -315,7 +315,7 @@ class MesosJobFramework @Inject() (
       val (jobName, _, _, _) = TaskUtils.parseTaskId(taskId)
 
       if (state != TaskState.TASK_STAGING) {
-        cancelKilledStatusUpdate(jobName)
+        cancelKilledStatusUpdate(taskId)
       }
 
       state match {

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/mesos/MesosJobFrameworkSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/mesos/MesosJobFrameworkSpec.scala
@@ -406,6 +406,9 @@ class MesosJobFrameworkSpec extends SpecificationWithJUnit with Mockito {
     val initialStatus =
       mesosJobFramework.runningTasks.get("foo").get.taskStatus.get
 
+    mesosJobFramework.startupTimers.get(
+      "ct:1454467003926:0:test2Execution:run") must beSome
+
     there was one(mesosJobFramework).
       scheduleKilledStatusFromInitial(initialStatus, 600)
 
@@ -416,6 +419,10 @@ class MesosJobFrameworkSpec extends SpecificationWithJUnit with Mockito {
     mesosJobFramework.statusUpdate(
       mesosJobFramework.mesosDriver.get(), runningState)
 
-    there was one(mesosJobFramework).cancelKilledStatusUpdate("test2Execution")
+    there was one(mesosJobFramework).cancelKilledStatusUpdate(
+      "ct:1454467003926:0:test2Execution:run")
+
+    mesosJobFramework.startupTimers.get(
+      "ct:1454467003926:0:test2Execution:run") must beNone
   }
 }


### PR DESCRIPTION
key by task, rather than by a mix of jobname/task